### PR TITLE
fix: 데이터 수정시에도 createdAt이 업데이트 되는 버그 해결

### DIFF
--- a/src/main/java/com/soda/common/BaseEntity.java
+++ b/src/main/java/com/soda/common/BaseEntity.java
@@ -19,6 +19,7 @@ public class BaseEntity {
     private Long id;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -79,6 +79,9 @@ public class RequestService {
         // request의 제목, 내용을 수정
         updateRequestFields(requestUpdateRequest, request);
 
+        requestRepository.save(request);
+        requestRepository.flush();
+
         return RequestUpdateResponse.fromEntity(request);
     }
 


### PR DESCRIPTION

# 요약
- 데이터 수정시에 `createdAt`이 업데이트 되는 버그 해결하였습니다.


# 연관 이슈
Closed #16 

# 수정한 코드
- `BaseEntity`의 `createdAt`필드에 `@Column(updatable = false)`를 달았음.

# 확인해야할 사항
- 데이터 생성시에 `updatedAt`은 `createdAt`과 동일하게 업데이트되는게 정상적인 동작이라고합니다.
- 데이터 수정시에는 `updatedAt`만 업데이트됩니다.