### PR TITLE
[Feature] JwtAuthenticationFilter에서 사용자정보를 요청 속성으로 추가

### DIFF
--- a/src/main/java/com/soda/global/security/auth/UserDetailsImpl.java
+++ b/src/main/java/com/soda/global/security/auth/UserDetailsImpl.java
@@ -66,4 +66,8 @@ public class UserDetailsImpl implements UserDetails {
         // 계정 활성화 여부를 반환하는 메서드
         return !member.getIsDeleted();
     }
+
+    public Long getId() {
+        return member.getId();
+    }
 }

--- a/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.soda.global.security.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soda.global.response.ApiResponseForm;
 import com.soda.global.response.ErrorCode;
+import com.soda.global.security.auth.UserDetailsImpl;
 import com.soda.global.security.config.SecurityProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -65,6 +66,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     userDetails, null, userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
+            // request에 사용자 정보 추가
+            addUserAttributes(request, userDetails);
+
             filterChain.doFilter(request, response);
 
         } catch (ExpiredJwtException e) {
@@ -76,6 +80,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             System.out.println(e.getMessage());
             sendErrorResponse(response, ErrorCode.UNEXPECTED_ERROR);
+        }
+    }
+
+    private void addUserAttributes(HttpServletRequest request, UserDetails userDetails) {
+        if (userDetails instanceof UserDetailsImpl) {
+            UserDetailsImpl userDetailsImpl = (UserDetailsImpl) userDetails;
+            request.setAttribute("authId", userDetailsImpl.getUsername());
+            request.setAttribute("memberId", userDetailsImpl.getId());
+            request.setAttribute("userRole", userDetailsImpl.getMember().getRole());
+        } else {
+            log.warn("UserDetails is not an instance of UserDetailsImpl.");
         }
     }
 


### PR DESCRIPTION

# 요약
JwtAuthenticationFilter에서 인증된 사용자의 ID와 역할을 HTTP 요청 속성(request attribute)으로 추가하여, 
컨트롤러에서 해당 정보를 쉽게 접근하고 사용할 수 있도록 수정했습니다. 
기존에는 @AuthenticationPrincipal 어노테이션을 통해 사용자 정보를 받았지만,
 필터에서 직접 요청 속성에 정보를 추가함으로써 컨트롤러에서 보다 유연하고 안전하게 
사용자 정보를 활용할 수 있게 되었습니다.






## 수정시 이점
1.  **유연성 향상**: 컨트롤러에서 `UserDetails` 객체에 직접 의존하지 않고 필요한 사용자 정보만 요청 속성에서 가져올 수 있습니다.
2.  **추가 정보 활용**: `UserDetails` 객체에서 제공하지 않는 추가적인 사용자 정보를 요청 속성에 추가하여 컨트롤러에서 활용할 수 있습니다.
3.  **테스트 용이성**: 단위 테스트 작성 시 요청 속성을 쉽게 모킹할 수 있습니다.
4.  **보안 강화**: 요청 속성은 서버 내부에서만 접근 가능하므로 헤더보다 안전하게 사용자 정보를 전달할 수 있습니다.
5.  **코드 간결성**: 컨트롤러에서 사용자 정보를 추출하는 코드가 간결해져 코드의 가독성과 유지보수성이 향상됩니다.


## 컨트롤러 사용 예시
```java
import jakarta.servlet.http.HttpServletRequest;
import org.springframework.web.bind.annotation.GetMapping;
import org.springframework.web.bind.annotation.RestController;

@RestController
public class MyController {

    @GetMapping("/api/user-info")
    public String getUserInfo(HttpServletRequest request) {
        String authId = (String) request.getAttribute("authId");
        Long id = (Long) request.getAttribute("id");
        String userRole = request.getAttribute("userRole").toString();

        return "authId: " + authId + ", id: " + id + ", userRole: " + userRole;
    }
}
```
# 연관 이슈
#30 

# Pull Request 체크리스트
## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?