### PR TITLE
[Refactor] updatedAt 원하는 필드 변경시에만 변경되게 리팩토링

### DIFF
--- a/src/main/java/com/soda/common/BaseEntity.java
+++ b/src/main/java/com/soda/common/BaseEntity.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
+@EntityListeners(CustomAuditingEntityListener.class)
 public class BaseEntity {
 
     @Getter

--- a/src/main/java/com/soda/common/CustomAuditingEntityListener.java
+++ b/src/main/java/com/soda/common/CustomAuditingEntityListener.java
@@ -57,27 +57,39 @@ public class CustomAuditingEntityListener {
 
         if (shouldUpdate) {
             try {
-                Field updatedAtField = entity.getClass().getDeclaredField("updatedAt");
+                Field updatedAtField = getFieldIncludingSuper(entity.getClass(), "updatedAt");
                 updatedAtField.setAccessible(true);
                 updatedAtField.set(entity, LocalDateTime.now());
-            } catch (NoSuchFieldException | IllegalAccessException e) {
+            } catch (Exception e) {
                 throw new RuntimeException("updatedAt 필드가 없거나 접근 불가합니다", e);
             }
         }
     }
 
+    // 수정된 @PrePersist 부분
     @PrePersist
     public void prePersist(Object entity) {
         try {
-            Field createdAtField = entity.getClass().getDeclaredField("createdAt");
+            Field createdAtField = getFieldIncludingSuper(entity.getClass(), "createdAt");
             createdAtField.setAccessible(true);
             createdAtField.set(entity, LocalDateTime.now());
 
-            Field updatedAtField = entity.getClass().getDeclaredField("updatedAt");
+            Field updatedAtField = getFieldIncludingSuper(entity.getClass(), "updatedAt");
             updatedAtField.setAccessible(true);
             updatedAtField.set(entity, LocalDateTime.now());
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private Field getFieldIncludingSuper(Class<?> clazz, String fieldName) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new RuntimeException(fieldName + " 필드가 없거나 접근 불가합니다");
     }
 }

--- a/src/main/java/com/soda/common/CustomAuditingEntityListener.java
+++ b/src/main/java/com/soda/common/CustomAuditingEntityListener.java
@@ -12,51 +12,57 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class CustomAuditingEntityListener {
 
-    private static final ThreadLocal<Map<Object, Object>> ORIGINAL_STATE = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<Map<Object, Map<String, Object>>> ORIGINAL_STATE = ThreadLocal.withInitial(HashMap::new);
 
     @PostLoad
     public void postLoad(Object entity) {
-        try {
-            Map<String, Object> state = new HashMap<>();
-            for (Field field : entity.getClass().getDeclaredFields()) {
+        Map<String, Object> trackedValues = new HashMap<>();
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(TrackUpdate.class)) {
                 field.setAccessible(true);
-                state.put(field.getName(), field.get(entity));
+                try {
+                    trackedValues.put(field.getName(), field.get(entity));
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
             }
-            ORIGINAL_STATE.get().put(entity, state);
-        } catch (Exception e) {
-            e.printStackTrace();
         }
+        ORIGINAL_STATE.get().put(entity, trackedValues);
     }
 
     @PreUpdate
     public void preUpdate(Object entity) {
-        try {
-            Map<String, Object> original = (Map<String, Object>) ORIGINAL_STATE.get().get(entity);
+        Map<String, Object> originalValues = ORIGINAL_STATE.get().get(entity);
+        boolean shouldUpdate = false;
 
-            boolean shouldUpdate = false;
-            for (String targetFieldName : List.of("content", "title")) { // 여기에 추적할 필드를 명시
-                Field field = entity.getClass().getDeclaredField(targetFieldName);
+        for (Field field : entity.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(TrackUpdate.class)) {
                 field.setAccessible(true);
-                Object currentValue = field.get(entity);
-                Object originalValue = original.get(targetFieldName);
-                if ((currentValue != null && !currentValue.equals(originalValue)) ||
-                        (currentValue == null && originalValue != null)) {
-                    shouldUpdate = true;
-                    break;
+                try {
+                    Object currentValue = field.get(entity);
+                    Object originalValue = originalValues.get(field.getName());
+                    if (!Objects.equals(currentValue, originalValue)) {
+                        shouldUpdate = true;
+                        break;
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
                 }
             }
+        }
 
-            if (shouldUpdate) {
+        if (shouldUpdate) {
+            try {
                 Field updatedAtField = entity.getClass().getDeclaredField("updatedAt");
                 updatedAtField.setAccessible(true);
                 updatedAtField.set(entity, LocalDateTime.now());
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException("updatedAt 필드가 없거나 접근 불가합니다", e);
             }
-
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/com/soda/common/CustomAuditingEntityListener.java
+++ b/src/main/java/com/soda/common/CustomAuditingEntityListener.java
@@ -1,0 +1,77 @@
+package com.soda.common;
+
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PostLoad;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CustomAuditingEntityListener {
+
+    private static final ThreadLocal<Map<Object, Object>> ORIGINAL_STATE = ThreadLocal.withInitial(HashMap::new);
+
+    @PostLoad
+    public void postLoad(Object entity) {
+        try {
+            Map<String, Object> state = new HashMap<>();
+            for (Field field : entity.getClass().getDeclaredFields()) {
+                field.setAccessible(true);
+                state.put(field.getName(), field.get(entity));
+            }
+            ORIGINAL_STATE.get().put(entity, state);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate(Object entity) {
+        try {
+            Map<String, Object> original = (Map<String, Object>) ORIGINAL_STATE.get().get(entity);
+
+            boolean shouldUpdate = false;
+            for (String targetFieldName : List.of("content", "title")) { // 여기에 추적할 필드를 명시
+                Field field = entity.getClass().getDeclaredField(targetFieldName);
+                field.setAccessible(true);
+                Object currentValue = field.get(entity);
+                Object originalValue = original.get(targetFieldName);
+                if ((currentValue != null && !currentValue.equals(originalValue)) ||
+                        (currentValue == null && originalValue != null)) {
+                    shouldUpdate = true;
+                    break;
+                }
+            }
+
+            if (shouldUpdate) {
+                Field updatedAtField = entity.getClass().getDeclaredField("updatedAt");
+                updatedAtField.setAccessible(true);
+                updatedAtField.set(entity, LocalDateTime.now());
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @PrePersist
+    public void prePersist(Object entity) {
+        try {
+            Field createdAtField = entity.getClass().getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(entity, LocalDateTime.now());
+
+            Field updatedAtField = entity.getClass().getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(entity, LocalDateTime.now());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/soda/common/TrackUpdate.java
+++ b/src/main/java/com/soda/common/TrackUpdate.java
@@ -1,0 +1,8 @@
+package com.soda.common;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackUpdate {
+}

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -21,6 +21,7 @@ public class Request extends BaseEntity {
     @TrackUpdate
     private String title;
 
+    @TrackUpdate
     @Lob
     private String content;
 

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -1,6 +1,7 @@
 package com.soda.request.entity;
 
 import com.soda.common.BaseEntity;
+import com.soda.common.TrackUpdate;
 import com.soda.member.entity.Member;
 import com.soda.project.entity.Task;
 import com.soda.request.enums.RequestStatus;
@@ -17,6 +18,7 @@ public class Request extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RequestStatus status;
 
+    @TrackUpdate
     private String title;
 
     @Lob


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- `updatedAt` 원하는 필드 변경시에만 변경되게 리팩토링

# 연관 이슈
Closed #29 

# 변경사항
- 기존 `BaseEntity`가 `AuditingEntityListener`를 EventListen하는 구조에서 `CustomAuditingEntityListener`를 EventListen하는 구조로 변경
- `CustomAuditingEntityListener`에서 `@TrackUpdate` 애너테이션이 붙어있는 필드가 변경될 때만 `updatedAt`이 업데이트 되도록 로직을 짰습니다.
- `@TrackUpdate`애너테이션도 수동으로 작성하였습니다

# 확인해야할 사항
- 이제 `updatedAt`이 업데이트되길 원하는 필드에 `@TrackUpdate` 애너테이션을 붙이면 해당 필드가 변경될 때만 `updatedAt`이 변경되게 됩니다.

# 사용 예시
```java
@Entity
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Getter
public class Request extends BaseEntity {

    @Enumerated(EnumType.STRING)
    private RequestStatus status;

    @TrackUpdate
    private String title;

    @TrackUpdate
    @Lob
    private String content;
```