### PR TITLE
[Refactor] ErrorCode Enum 분리 (Member, Company, Auth)

### DIFF
--- a/src/main/java/com/soda/global/response/CommonErrorCode.java
+++ b/src/main/java/com/soda/global/response/CommonErrorCode.java
@@ -15,30 +15,14 @@ public enum CommonErrorCode implements ErrorCode {
     BAD_GATEWAY("502", "Bad Gateway: The server received an invalid response from the upstream server.", HttpStatus.BAD_GATEWAY),
     SERVICE_UNAVAILABLE("503", "Service Unavailable: The server is temporarily unable to handle the request.", HttpStatus.SERVICE_UNAVAILABLE),
 
-    // 인증 관련 추가 오류
+    // 공통 에러
     UNEXPECTED_ERROR("1000", "Unexpected Error: An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR),
-
-    // service 로직 오류 메시지
-
-
-    INVALID_CREDENTIALS("2001", "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-    TOKEN_EXPIRED("2002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_TOKEN("2003", "잘못된 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    ACCESS_DENIED("2004", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    NOT_FOUND_MEMBER("2005", "멤버를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-    NOT_FOUND_REFRESH_TOKEN("2006", "Refresh token을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_REFRESH_TOKEN("2007", "유효하지 않은 Refresh token입니다.", HttpStatus.UNAUTHORIZED),
-    DUPLICATE_AUTH_ID("2008", "이미 사용 중인 아이디입니다.", HttpStatus.BAD_REQUEST),
-    MAIL_SEND_FAILED("2009", "메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    NOT_FOUND_COMPANY("2010", "회사를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-
 
     // 승인요청 관련 오류 메시지
     USER_NOT_IN_PROJECT_DEV("3000", "This user is not in current project or not in project's dev company", HttpStatus.BAD_REQUEST),
     REQUEST_NOT_FOUND("3001", "This request id is not found in Requests", HttpStatus.NOT_FOUND),
     USER_NOT_WRITE_REQUEST("3002", "This user doesn't write this request", HttpStatus.BAD_REQUEST),
-    TASK_NOT_FOUND("3003", "This task is not found", HttpStatus.NOT_FOUND),
-    ;
+    TASK_NOT_FOUND("3003", "This task is not found", HttpStatus.NOT_FOUND);
 
 
     private final String code;

--- a/src/main/java/com/soda/global/security/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/soda/global/security/auth/UserDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package com.soda.global.security.auth;
 import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.GeneralException;
 import com.soda.member.entity.Member;
+import com.soda.member.error.MemberErrorCode;
 import com.soda.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                 .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND));
 
         if (member.getIsDeleted()) {
-            throw new GeneralException(CommonErrorCode.NOT_FOUND_MEMBER);
+            throw new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
         }
         return new UserDetailsImpl(member);
 

--- a/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.soda.global.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soda.global.response.ApiResponseForm;
+import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.ErrorCode;
 import com.soda.global.security.auth.UserDetailsImpl;
 import com.soda.global.security.config.SecurityProperties;
@@ -83,7 +84,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             sendErrorResponse(response, MemberErrorCode.NOT_FOUND_MEMBER);
         } catch (Exception e) {
             log.error("JWT 인증 필터 중 인증 실패 에러 발생: {}", e.getMessage(), e);
-            sendErrorResponse(response, AuthErrorCode.AUTHENTICATION_FAILED);
+            sendErrorResponse(response, CommonErrorCode.UNEXPECTED_ERROR);
         }
     }
 

--- a/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/soda/global/security/jwt/JwtAuthenticationFilter.java
@@ -2,9 +2,11 @@ package com.soda.global.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.soda.global.response.ApiResponseForm;
-import com.soda.global.response.CommonErrorCode;
+import com.soda.global.response.ErrorCode;
 import com.soda.global.security.auth.UserDetailsImpl;
 import com.soda.global.security.config.SecurityProperties;
+import com.soda.member.error.AuthErrorCode;
+import com.soda.member.error.MemberErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -30,7 +32,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -53,7 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
             // 토큰 검증 시도
             if (!jwtTokenProvider.validateToken(token)) {
-                sendErrorResponse(response, CommonErrorCode.INVALID_TOKEN);
+                sendErrorResponse(response, AuthErrorCode.INVALID_TOKEN);
                 return;
             }
 
@@ -72,14 +73,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
 
         } catch (ExpiredJwtException e) {
-            sendErrorResponse(response, CommonErrorCode.TOKEN_EXPIRED);
+            log.error("JWT 인증 필터 중 토큰 만료 에러 발생: {}", e.getMessage(), e);
+            sendErrorResponse(response, AuthErrorCode.TOKEN_EXPIRED);
         } catch (MalformedJwtException | UnsupportedJwtException | SignatureException | IllegalArgumentException e) {
-            sendErrorResponse(response, CommonErrorCode.INVALID_TOKEN);
+            log.error("JWT 인증 필터 중 유효하지 않은 토큰 에러 발생: {}", e.getMessage(), e);
+            sendErrorResponse(response, AuthErrorCode.INVALID_TOKEN);
         } catch (UsernameNotFoundException e) {
-            sendErrorResponse(response, CommonErrorCode.NOT_FOUND_MEMBER);
+            log.error("JWT 인증 필터 중 멤버를 찾을 수 없음: {}", e.getMessage(), e);
+            sendErrorResponse(response, MemberErrorCode.NOT_FOUND_MEMBER);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
-            sendErrorResponse(response, CommonErrorCode.UNEXPECTED_ERROR);
+            log.error("JWT 인증 필터 중 인증 실패 에러 발생: {}", e.getMessage(), e);
+            sendErrorResponse(response, AuthErrorCode.AUTHENTICATION_FAILED);
         }
     }
 
@@ -90,11 +94,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             request.setAttribute("memberId", userDetailsImpl.getId());
             request.setAttribute("userRole", userDetailsImpl.getMember().getRole());
         } else {
-            log.warn("UserDetails is not an instance of UserDetailsImpl.");
+            log.warn("UserDetailsImpl 타입의 인스턴스가 아닙니다.");
         }
     }
 
-    private void sendErrorResponse(HttpServletResponse response, CommonErrorCode errorCode) {
+    private void sendErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
         try {
             if (response.isCommitted()) {
                 return; // 이미 응답이 전송되었으면 처리하지 않음
@@ -111,12 +115,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             out.write(jsonResponse.getBytes(StandardCharsets.UTF_8));
             out.flush();
         } catch (Exception e) {
-            // 로깅만 하고, 여기서 다시 예외 던지면 또 문제가 생길 수 있으므로 swallow
-            System.err.println("sendErrorResponse 중 에러 발생: " + e.getMessage());
-            e.printStackTrace();
+            log.error("sendErrorResponse 중 에러 발생: {}", e.getMessage(), e);
         }
     }
-
 
     private boolean isExcludedPath(String path) {
         for (String excludedPath : securityProperties.getExcludedPaths()) {

--- a/src/main/java/com/soda/member/error/AuthErrorCode.java
+++ b/src/main/java/com/soda/member/error/AuthErrorCode.java
@@ -1,0 +1,41 @@
+package com.soda.member.error;
+
+import com.soda.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+
+    INVALID_CREDENTIALS("2001", "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED("2002", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TOKEN("2003", "잘못된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED("2004", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NOT_FOUND_REFRESH_TOKEN("2006", "Refresh token을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("2007", "유효하지 않은 Refresh token입니다.", HttpStatus.UNAUTHORIZED),
+    MAIL_SEND_FAILED("2009", "메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTHENTICATION_FAILED("2010", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    AuthErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/soda/member/error/CompanyErrorCode.java
+++ b/src/main/java/com/soda/member/error/CompanyErrorCode.java
@@ -1,0 +1,36 @@
+package com.soda.member.error;
+
+import com.soda.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum CompanyErrorCode implements ErrorCode {
+
+    NOT_FOUND_COMPANY("2010", "회사를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_COMPANY_NUMBER("2011", "중복된 사업자 등록번호 입니다.", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_DELETED_COMPANY("2012", "삭제된 회사를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    CompanyErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/soda/member/error/MemberErrorCode.java
+++ b/src/main/java/com/soda/member/error/MemberErrorCode.java
@@ -1,0 +1,35 @@
+package com.soda.member.error;
+
+import com.soda.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum MemberErrorCode implements ErrorCode {
+    NOT_FOUND_MEMBER("2005", "멤버를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_AUTH_ID("2008", "이미 사용 중인 아이디입니다.", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_COMPANY("2010", "회사를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    MemberErrorCode (String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/soda/member/service/CompanyService.java
+++ b/src/main/java/com/soda/member/service/CompanyService.java
@@ -1,14 +1,15 @@
 package com.soda.member.service;
 
-import com.soda.global.response.ErrorCode;
 import com.soda.global.response.GeneralException;
 import com.soda.member.dto.company.CompanyCreateRequest;
 import com.soda.member.dto.company.CompanyUpdateRequest;
 import com.soda.member.dto.company.CompanyResponse;
 import com.soda.member.dto.company.MemberResponse;
 import com.soda.member.entity.Company;
+import com.soda.member.error.CompanyErrorCode;
 import com.soda.member.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -32,9 +34,9 @@ public class CompanyService {
      */
     @Transactional
     public CompanyResponse createCompany(CompanyCreateRequest request) {
-        // 사업자 등록번호 중복 확인
         if (companyRepository.findByCompanyNumber(request.getCompanyNumber()).isPresent()) {
-            throw new GeneralException(ErrorCode.DUPLICATE_COMPANY_NUMBER);
+            log.error("회사 생성 실패: 사업자 등록번호 중복 - {}", request.getCompanyNumber());
+            throw new GeneralException(CompanyErrorCode.DUPLICATE_COMPANY_NUMBER);
         }
 
         Company company = Company.builder()
@@ -46,8 +48,10 @@ public class CompanyService {
                 .build();
 
         Company savedCompany = companyRepository.save(company);
+        log.info("회사 생성 성공: {}", savedCompany.getId());
         return CompanyResponse.fromEntity(savedCompany);
     }
+
     /**
      * 모든 회사 조회 메서드
      *
@@ -68,7 +72,10 @@ public class CompanyService {
      */
     public CompanyResponse getCompanyById(Long id) {
         Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_COMPANY));
+                .orElseThrow(() -> {
+                    log.error("회사 조회 실패: 회사를 찾을 수 없음 - {}", id);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
         return CompanyResponse.fromEntity(company);
     }
 
@@ -83,19 +90,22 @@ public class CompanyService {
     @Transactional
     public CompanyResponse updateCompany(Long id, CompanyUpdateRequest request) {
         Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_COMPANY));
+                .orElseThrow(() -> {
+                    log.error("회사 수정 실패: 회사를 찾을 수 없음 - {}", id);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
 
-        // 수정하려는 사업자 등록번호가 다른 회사의 사업자 등록번호와 중복되는지 확인
         Optional<Company> existingCompany = companyRepository.findByCompanyNumber(request.getCompanyNumber());
         if (existingCompany.isPresent() && !existingCompany.get().getId().equals(id)) {
-            throw new GeneralException(ErrorCode.DUPLICATE_COMPANY_NUMBER);
+            log.error("회사 수정 실패: 사업자 등록번호 중복 - {}", request.getCompanyNumber());
+            throw new GeneralException(CompanyErrorCode.DUPLICATE_COMPANY_NUMBER);
         }
 
         company.updateCompany(request);
         Company updatedCompany = companyRepository.save(company);
+        log.info("회사 수정 성공: {}", updatedCompany.getId());
         return CompanyResponse.fromEntity(updatedCompany);
     }
-
 
     /**
      * 회사 삭제 메서드 (소프트 삭제)
@@ -106,10 +116,14 @@ public class CompanyService {
     @Transactional
     public void deleteCompany(Long id) {
         Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_COMPANY));
+                .orElseThrow(() -> {
+                    log.error("회사 삭제 실패: 회사를 찾을 수 없음 - {}", id);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
 
         company.delete();
         companyRepository.save(company);
+        log.info("회사 삭제 성공: {}", id);
     }
 
     /**
@@ -122,10 +136,14 @@ public class CompanyService {
     @Transactional
     public CompanyResponse restoreCompany(Long id) {
         Company company = companyRepository.findByIdAndIsDeletedTrue(id)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_COMPANY));
+                .orElseThrow(() -> {
+                    log.error("회사 복구 실패: 삭제된 회사를 찾을 수 없음 - {}", id);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
 
         company.markAsActive();
         Company restoredCompany = companyRepository.save(company);
+        log.info("회사 복구 성공: {}", restoredCompany.getId());
         return CompanyResponse.fromEntity(restoredCompany);
     }
 
@@ -138,7 +156,10 @@ public class CompanyService {
      */
     public List<MemberResponse> getCompanyMembers(Long companyId) {
         Company company = companyRepository.findByIdAndIsDeletedFalse(companyId)
-                .orElseThrow(() -> new GeneralException(ErrorCode.NOT_FOUND_COMPANY));
+                .orElseThrow(() -> {
+                    log.error("회사 멤버 조회 실패: 회사를 찾을 수 없음 - {}", companyId);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
 
         return company.getMemberList().stream()
                 .map(MemberResponse::fromEntity)

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -6,6 +6,7 @@ import com.soda.global.security.auth.UserDetailsImpl;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.MemberProjectRole;
 import com.soda.member.enums.MemberRole;
+import com.soda.member.error.MemberErrorCode;
 import com.soda.member.repository.MemberRepository;
 import com.soda.project.entity.Task;
 import com.soda.project.repository.TaskRepository;
@@ -39,12 +40,12 @@ public class RequestService {
         // userDetails.getMember.getId를 바탕으로 (레프트)페치조인해 memberProject와 함께 영속성 컨텍스트에 등록
         System.out.println(userDetails.getMember().getId());
         Member member = memberRepository.findWithProjectsById(userDetails.getMember().getId())
-                .orElseThrow(() -> new GeneralException(CommonErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
         Task task = getTaskOrThrow(requestCreateRequest.getTaskId());
 
         // 현재 프로젝트에 속한 "개발사"의 멤버가 아니고, 어드민도 아니면 USER_NOT_IN_PROJECT_DEV 반환
         if (!isDevInCurrentProject(requestCreateRequest.getProjectId(), member) && !isAdmin(member)) {
-            throw new GeneralException(ErrorCode.USER_NOT_IN_PROJECT_DEV);
+            throw new GeneralException(CommonErrorCode.USER_NOT_IN_PROJECT_DEV);
         }
 
         Request request = Request.builder()
@@ -125,7 +126,7 @@ public class RequestService {
         return member.getRole() == MemberRole.ADMIN;
     }
 
-    // Request(승인요청)을 작성한 멤버가 (인자의)Member인지 확인하는 메서드
+    // Request(승인요청)을 작성한 멤버가 (인자의) Member인지 확인하는 메서드
     private static void validateRequestWriter(Request request, Member member) {
         boolean isRequestWriter = request.getMember().getId().equals(member.getId());
         if (!isRequestWriter) { throw new GeneralException(CommonErrorCode.USER_NOT_WRITE_REQUEST); }


### PR DESCRIPTION

# 요약

## 1. ErrorCode 분리
- MemberErrorCode: 멤버 관련 에러 코드 관리
- CompanyErrorCode: 회사 관련 에러 코드 관리
- AuthErrorCode: 인증 관련 에러 코드 관리

## 2. 서비스 코드 수정
- AuthService, CompanyService에서 분리된 도메인별 에러 코드를 사용하도록 수정
- 예외 처리 개선 및 명확한 예외 메시지 추가


## 3. JwtAuthenticationFilter 수정
- 에러 코드 수정 및 로그 메시지 개선


# 연관 이슈
#35 

# Pull Request 체크리스트


## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
