### PR TITLE
[Feature] 게시글 파일 첨부/삭제 기능 개발

### DIFF
--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -2,11 +2,15 @@ package com.soda.article.controller;
 
 import com.soda.article.domain.article.*;
 import com.soda.article.service.ArticleService;
+import com.soda.common.file.dto.FileDeleteResponse;
+import com.soda.common.file.dto.FileUploadResponse;
+import com.soda.common.file.service.FileService;
 import com.soda.global.response.ApiResponseForm;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,6 +19,7 @@ import java.util.List;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final FileService fileService;
 
     @PostMapping("/articles")
     public ResponseEntity<ApiResponseForm<ArticleCreateResponse>> createArticle(@RequestBody ArticleCreateRequest request, HttpServletRequest user) {
@@ -60,6 +65,23 @@ public class ArticleController {
         String userRole = (String) user.getAttribute("userRole").toString();
         ArticleModifyResponse response = articleService.updateArticle(userId, userRole, articleId, request);
         return ResponseEntity.ok(ApiResponseForm.success(response, "Article 수정 성공"));
+    }
+
+    @PostMapping("/articles/{articleId}/files")
+    public ResponseEntity<ApiResponseForm<?>> uploadFiles(@PathVariable Long articleId,
+                                                          @RequestPart("file") List<MultipartFile> files,
+                                                          HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        FileUploadResponse fileUploadResponse = fileService.upload("article", articleId, memberId, files);
+        return ResponseEntity.ok(ApiResponseForm.success(fileUploadResponse));
+    }
+
+    @DeleteMapping("articles/{articleId}/files/{fileId}")
+    public ResponseEntity<ApiResponseForm<?>> deleteFile(@PathVariable Long fileId,
+                                                         HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        FileDeleteResponse fileDeleteResponse = fileService.delete("article", memberId, fileId);
+        return ResponseEntity.ok(ApiResponseForm.success(fileDeleteResponse));
     }
 
 }

--- a/src/main/java/com/soda/article/domain/article/ArticleCreateResponse.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleCreateResponse.java
@@ -33,7 +33,7 @@ public class ArticleCreateResponse {
                 .deadLine(article.getDeadline())
                 .memberName(article.getMember().getName())
                 .stageName(article.getStage().getName())
-                .parentArticleId(article.getParentArticle().getId())
+                .parentArticleId(article.getParentArticle() == null ? null : article.getParentArticle().getId())
                 .fileList(article.getArticleFileList().stream()
                         .map(file -> ArticleFileDTO.builder()
                                 .name(file.getName())

--- a/src/main/java/com/soda/article/entity/ArticleFile.java
+++ b/src/main/java/com/soda/article/entity/ArticleFile.java
@@ -1,7 +1,10 @@
 package com.soda.article.entity;
 
-import com.soda.common.BaseEntity;
-import jakarta.persistence.*;
+import com.soda.common.file.model.FileBase;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class ArticleFile extends BaseEntity {
+public class ArticleFile extends FileBase {
 
     private String name;
 
@@ -29,6 +32,11 @@ public class ArticleFile extends BaseEntity {
 
     public void delete() {
         this.markAsDeleted();
+    }
+
+    @Override
+    public Long getDomainId() {
+        return article.getId();
     }
 
     public void reActive() {

--- a/src/main/java/com/soda/article/error/ArticleErrorCode.java
+++ b/src/main/java/com/soda/article/error/ArticleErrorCode.java
@@ -1,6 +1,5 @@
 package com.soda.article.error;
 
-import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.ErrorCode;
 import org.springframework.http.HttpStatus;
 
@@ -8,7 +7,9 @@ public enum ArticleErrorCode implements ErrorCode {
     INVALID_INPUT("1101", "Invalid Input", HttpStatus.BAD_REQUEST),
     ARTICLE_ALREADY_DELETED("1102","This article is already deleted", HttpStatus.NOT_FOUND),
     INVALID_ARTICLE("1103", "The Article does not exist", HttpStatus.NOT_FOUND),
-    PARENT_ARTICLE_NOT_FOUND("1104", "This parent article does not exist", HttpStatus.NOT_FOUND);
+    PARENT_ARTICLE_NOT_FOUND("1104", "This parent article does not exist", HttpStatus.NOT_FOUND),
+    USER_NOT_UPLOAD_ARTICLE_FILE("1105", "This user does not upload article_file", HttpStatus.NOT_FOUND),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
@@ -1,4 +1,69 @@
 package com.soda.article.strategy;
 
-public class ArticleFileStrategy {
+import com.soda.article.entity.Article;
+import com.soda.article.entity.ArticleFile;
+import com.soda.article.repository.ArticleFileRepository;
+import com.soda.article.repository.ArticleRepository;
+import com.soda.common.file.strategy.FileStrategy;
+import com.soda.global.response.GeneralException;
+import com.soda.article.error.ArticleErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleFileStrategy implements FileStrategy<Article, ArticleFile> {
+    
+    private final ArticleRepository articleRepository;
+    private final ArticleFileRepository articleFileRepository;
+
+    @Override
+    public String getSupportedDomain() {
+        return "article";
+    }
+
+    @Override
+    public Article getDomainOrThrow(Long domainId) {
+        return articleRepository.findById(domainId)
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.INVALID_ARTICLE));
+    }
+
+    @Override
+    public void validateWriter(Long memberId, Article article) {
+        if (!article.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ArticleErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Override
+    public ArticleFile toEntity(MultipartFile file, String url, Article article) {
+        return ArticleFile.builder()
+                .name(file.getOriginalFilename())
+                .url(url)
+                .article(article)
+                .build();
+    }
+
+    @Override
+    public void saveAll(List<ArticleFile> entities) {
+        articleFileRepository.saveAll(entities);
+    }
+
+    @Override
+    public ArticleFile getFileOrThrow(Long fileId) {
+        return articleFileRepository.findById(fileId)
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.INVALID_ARTICLE));
+    }
+
+    @Override
+    public void validateFileUploader(Long memberId, ArticleFile file) {
+        if (!file.getArticle().getMember().getId().equals(memberId)) {
+            throw new GeneralException(ArticleErrorCode.USER_NOT_UPLOAD_ARTICLE_FILE);
+        }
+    }
 }

--- a/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
@@ -1,0 +1,4 @@
+package com.soda.article.strategy;
+
+public class ArticleFileStrategy {
+}

--- a/src/main/java/com/soda/request/strategy/RequestFileStrategy.java
+++ b/src/main/java/com/soda/request/strategy/RequestFileStrategy.java
@@ -1,4 +1,4 @@
-package com.soda.request.service;
+package com.soda.request.strategy;
 
 import com.soda.common.file.strategy.FileStrategy;
 import com.soda.global.response.GeneralException;

--- a/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
@@ -1,4 +1,4 @@
-package com.soda.request.service;
+package com.soda.request.strategy;
 
 import com.soda.common.file.strategy.FileStrategy;
 import com.soda.global.response.GeneralException;


### PR DESCRIPTION

# 요약
게시글 파일 첨부/삭제 기능 개발

# 연관 이슈
Closed #58 

# 작성한 코드
- ArticleFileStrategy(게시글 파일 전략패턴 구현체 작성)
- ArticleFile이 Filebase라는 추상클래스를 상속받게하고 구현해야할 추상메서드를 구현
- ArticleController에 파일 첨부/삭제 API 구현

# 확인해야할 사항
- 파일 업로드 테스트중 Article POST시 500상태코드가 반환되는 에러가 발생했었는데, ArticleCreateResponse에서 article의 parentArticleId가 null인데 get하려고 해서 발생한 문제였습니다. 삼항연산자로 null일 때 반환값 처리를 해주어 해결하였습니다.