### PR TITLE
[Refactor] Project Service 리팩토링

### DIFF
--- a/src/main/java/com/soda/member/service/CompanyService.java
+++ b/src/main/java/com/soda/member/service/CompanyService.java
@@ -73,11 +73,7 @@ public class CompanyService {
      * @throws GeneralException 회사를 찾을 수 없는 경우 발생
      */
     public CompanyResponse getCompanyById(Long id) {
-        Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> {
-                    log.error("회사 조회 실패: 회사를 찾을 수 없음 - {}", id);
-                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
-                });
+        Company company = getCompany(id);
         return CompanyResponse.fromEntity(company);
     }
 
@@ -91,11 +87,7 @@ public class CompanyService {
      */
     @Transactional
     public CompanyResponse updateCompany(Long id, CompanyUpdateRequest request) {
-        Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> {
-                    log.error("회사 수정 실패: 회사를 찾을 수 없음 - {}", id);
-                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
-                });
+        Company company = getCompany(id);
 
         Optional<Company> existingCompany = companyRepository.findByCompanyNumber(request.getCompanyNumber());
         if (existingCompany.isPresent() && !existingCompany.get().getId().equals(id)) {
@@ -117,11 +109,7 @@ public class CompanyService {
      */
     @Transactional
     public void deleteCompany(Long id) {
-        Company company = companyRepository.findByIdAndIsDeletedFalse(id)
-                .orElseThrow(() -> {
-                    log.error("회사 삭제 실패: 회사를 찾을 수 없음 - {}", id);
-                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
-                });
+        Company company = getCompany(id);
 
         company.delete();
         companyRepository.save(company);
@@ -137,11 +125,7 @@ public class CompanyService {
      */
     @Transactional
     public CompanyResponse restoreCompany(Long id) {
-        Company company = companyRepository.findByIdAndIsDeletedTrue(id)
-                .orElseThrow(() -> {
-                    log.error("회사 복구 실패: 삭제된 회사를 찾을 수 없음 - {}", id);
-                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
-                });
+        Company company = getCompany(id);
 
         company.markAsActive();
         Company restoredCompany = companyRepository.save(company);
@@ -157,14 +141,18 @@ public class CompanyService {
      * @throws GeneralException 회사를 찾을 수 없는 경우 발생
      */
     public List<MemberResponse> getCompanyMembers(Long companyId) {
-        Company company = companyRepository.findByIdAndIsDeletedFalse(companyId)
-                .orElseThrow(() -> {
-                    log.error("회사 멤버 조회 실패: 회사를 찾을 수 없음 - {}", companyId);
-                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
-                });
+        Company company = getCompany(companyId);
 
         return company.getMemberList().stream()
                 .map(MemberResponse::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    public Company getCompany(Long companyId) {
+        return companyRepository.findByIdAndIsDeletedFalse(companyId)
+                .orElseThrow(() -> {
+                    log.error("회사 멤버 조회 실패: 회사를 찾을 수 없음 - {}", companyId);
+                    return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
+                });
     }
 }

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -1,0 +1,19 @@
+package com.soda.member.service;
+
+import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Member;
+import com.soda.member.repository.MemberRepository;
+import com.soda.project.error.ProjectErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member findByIdAndIsDeletedFalse(Long memberId) {
+        return memberRepository.findByIdAndIsDeletedFalse(memberId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -6,7 +6,9 @@ import com.soda.member.repository.MemberRepository;
 import com.soda.project.error.ProjectErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class MemberService {

--- a/src/main/java/com/soda/project/service/CompanyProjectService.java
+++ b/src/main/java/com/soda/project/service/CompanyProjectService.java
@@ -1,0 +1,59 @@
+package com.soda.project.service;
+
+import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Company;
+import com.soda.member.enums.CompanyProjectRole;
+import com.soda.member.service.CompanyService;
+import com.soda.project.domain.CompanyProjectDTO;
+import com.soda.project.entity.CompanyProject;
+import com.soda.project.entity.Project;
+import com.soda.project.error.ProjectErrorCode;
+import com.soda.project.repository.CompanyProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyProjectService {
+    private final CompanyProjectRepository companyProjectRepository;
+    private final CompanyService companyService;
+    private final ProjectService projectService;
+
+    public void assignCompanyToProject(Long companyId, Long projectId, CompanyProjectRole role) {
+        Company company = companyService.getCompany(companyId);
+        Project project = projectService.getProjectById(projectId);
+
+        if (!company.getIsDeleted() && !companyProjectRepository.existsByCompanyAndProject(company, project)) {
+            CompanyProjectDTO companyProjectDTO = CompanyProjectDTO.builder()
+                    .companyId(company.getId())
+                    .projectId(project.getId())
+                    .companyProjectRole(role)
+                    .build();
+
+            // DTO -> Entity
+            CompanyProject companyProject = companyProjectDTO.toEntity(company, project, role);
+
+            // 데이터베이스에 회사-프로젝트 관계 저장
+            companyProjectRepository.save(companyProject);
+        }
+    }
+
+    public CompanyProject findByProjectAndCompanyProjectRole(Project project, CompanyProjectRole role) {
+        return companyProjectRepository.findByProjectAndCompanyProjectRole(project, role)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.COMPANY_NOT_FOUND));
+    }
+
+    public List<CompanyProject> findByProject(Project project) {
+        return companyProjectRepository.findByProject(project);
+    }
+
+    public void saveAll(List<CompanyProject> companyProjects) {
+        companyProjectRepository.saveAll(companyProjects);
+    }
+
+    public boolean existsByCompanyAndProject(Company company, Project project) {
+        return companyProjectRepository.existsByCompanyAndProject(company, project);
+    }
+}

--- a/src/main/java/com/soda/project/service/CompanyProjectService.java
+++ b/src/main/java/com/soda/project/service/CompanyProjectService.java
@@ -9,11 +9,13 @@ import com.soda.project.entity.CompanyProject;
 import com.soda.project.entity.Project;
 import com.soda.project.error.ProjectErrorCode;
 import com.soda.project.repository.CompanyProjectRepository;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class CompanyProjectService {

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -45,4 +45,12 @@ public class MemberProjectService {
     public List<MemberProject> findByProject(Project project) {
         return memberProjectRepository.findByProject(project);
     }
+    
+    public MemberProject createMemberProject(Member member, Project project, MemberProjectRole role) {
+        return MemberProject.builder()
+                .member(member)
+                .project(project)
+                .memberProjectRole(role)
+                .build();
+    }
 }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -1,0 +1,48 @@
+package com.soda.project.service;
+
+import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberProjectRole;
+import com.soda.project.entity.MemberProject;
+import com.soda.project.entity.Project;
+import com.soda.project.repository.MemberProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProjectService {
+    private final MemberProjectRepository memberProjectRepository;
+
+    public boolean existsByMemberAndProjectAndIsDeletedFalse(Member member, Project project) {
+        return memberProjectRepository.existsByMemberAndProjectAndIsDeletedFalse(member, project);
+    }
+
+    public void save(MemberProject memberProject) {
+        memberProjectRepository.save(memberProject);  // 새로운 멤버를 프로젝트에 추가
+    }
+
+    public List<Member> getMembersByRole(Project project, MemberProjectRole role) {
+        return memberProjectRepository.findByProjectAndRoleAndIsDeletedFalse(project, role).stream()
+                .map(MemberProject::getMember)
+                .collect(Collectors.toList());
+    }
+
+    public List<MemberProject> findByProjectAndRole(Project project, MemberProjectRole role) {
+        return memberProjectRepository.findByProjectAndRole(project, role);
+    }
+
+    public void saveAll(List<MemberProject> memberProjects) {
+        memberProjectRepository.saveAll(memberProjects);
+    }
+
+    public MemberProject findByMemberAndProjectAndRole(Member member, Project project, MemberProjectRole role) {
+        return memberProjectRepository.findByMemberAndProjectAndRole(member, project, role);
+    }
+
+    public List<MemberProject> findByProject(Project project) {
+        return memberProjectRepository.findByProject(project);
+    }
+}

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -5,12 +5,14 @@ import com.soda.member.enums.MemberProjectRole;
 import com.soda.project.entity.MemberProject;
 import com.soda.project.entity.Project;
 import com.soda.project.repository.MemberProjectRepository;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class MemberProjectService {
@@ -45,7 +47,7 @@ public class MemberProjectService {
     public List<MemberProject> findByProject(Project project) {
         return memberProjectRepository.findByProject(project);
     }
-    
+
     public MemberProject createMemberProject(Member member, Project project, MemberProjectRole role) {
         return MemberProject.builder()
                 .member(member)

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -98,7 +98,7 @@ public class  ProjectService {
             // 이미 멤버가 프로젝트에 존재하는지 확인
             if (!memberProjectService.existsByMemberAndProjectAndIsDeletedFalse(member, project)) {
                 members.add(member);
-                MemberProject memberProject = createMemberProject(member, project, memberRole);
+                MemberProject memberProject = memberProjectService.createMemberProject(member, project, memberRole);
                 memberProjectService.save(memberProject);  // 새로운 멤버를 프로젝트에 추가
             }
         }
@@ -304,21 +304,13 @@ public class  ProjectService {
                 }
             } else {
                 // 새 멤버 프로젝트는 새로 생성
-                MemberProject newMemberProject = createMemberProject(member, project, role);
+                MemberProject newMemberProject = memberProjectService.createMemberProject(member, project, role);
                 newMemberProjects.add(newMemberProject);
             }
         }
 
         // 새로 생성된 멤버 프로젝트들을 저장
         memberProjectService.saveAll(newMemberProjects);
-    }
-
-    private MemberProject createMemberProject(Member member, Project project, MemberProjectRole role) {
-        return MemberProject.builder()
-                .member(member)
-                .project(project)
-                .memberProjectRole(role)
-                .build();
     }
 
     public Project getProjectById(Long projectId) {

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -13,7 +13,7 @@ import com.soda.project.entity.MemberProject;
 import com.soda.project.entity.Project;
 import com.soda.project.error.ProjectErrorCode;
 import com.soda.project.repository.ProjectRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class  ProjectService {
@@ -216,6 +217,7 @@ public class  ProjectService {
         - 개발사 수정, 관리자/직원 수정
         - 고객사 수정, 관리자/직원 수정
      */
+    @Transactional
     public ProjectCreateResponse updateProject(Long projectId, ProjectCreateRequest request) {
         // 1. 프로젝트 존재 여부 체크
         Project project = getProjectById(projectId);


### PR DESCRIPTION

# 요약

Project service 로직에서 repository를 참조하지 않고 service를 참조하도록 개인 리팩토링을 진행하였습니다,


# 연관 이슈
#57 

# 확인할 사항
### 1. CompanyProjectService, MemberProjectService 생성
- 객체에 적절한 책임을 부여해 결합도를 낮추고 응집도를 높여 변경에 용이한 시스템을 구성하기 위해 companyProject, memberProject 관련 로직들을 전부 각각 service 파일로 분리했습니다.
### 2. CompanyService 로직 변경
- `getCompany()`는 id로 회사를 조회하는 메서드입니다.
- 이를 통해 반복회는 코드를 줄이고 project service 쪽에서도 참조 가능하도록 변경하였습니다.
### 3. MemberService 생성
- 멤버 관련 로직을 MemberService에 따로 분리하였습니다.