### PR TITLE
[Refactor] Member, Company 리팩토링

### DIFF
--- a/src/main/java/com/soda/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/soda/member/dto/MemberUpdateRequest.java
@@ -11,7 +11,7 @@ public class MemberUpdateRequest {
     private String authId;
     private String email;
     private MemberRole role;
-    private String companyName;
+    private Long companyId;
     private String position;
     private String phoneNumber;
 }

--- a/src/main/java/com/soda/member/dto/SignupRequest.java
+++ b/src/main/java/com/soda/member/dto/SignupRequest.java
@@ -11,7 +11,7 @@ public class SignupRequest {
     private String authId;
     private String password;
     private MemberRole role;
-    private String companyName;
+    private Long companId;
     private String position;
     private String phoneNumber;
 }

--- a/src/main/java/com/soda/member/entity/Member.java
+++ b/src/main/java/com/soda/member/entity/Member.java
@@ -71,7 +71,7 @@ public class Member extends BaseEntity {
         if (request.getRole()!=null){
             this.role = request.getRole();
         }
-        if (request.getCompanyName()!=null){
+        if (company!=null){
             this.company = company;
         }
     }

--- a/src/main/java/com/soda/member/error/AuthErrorCode.java
+++ b/src/main/java/com/soda/member/error/AuthErrorCode.java
@@ -13,7 +13,8 @@ public enum AuthErrorCode implements ErrorCode {
     NOT_FOUND_REFRESH_TOKEN("2006", "Refresh Token을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN("2007", "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),
     MAIL_SEND_FAILED("2009", "메일 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    AUTHENTICATION_FAILED("2010", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED);
+    AUTHENTICATION_FAILED("2010", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_FOUND_EMAIL("2011", "가입되지 않은 이메일 입니다.", HttpStatus.UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/member/repository/CompanyRepository.java
+++ b/src/main/java/com/soda/member/repository/CompanyRepository.java
@@ -11,12 +11,8 @@ import java.util.Optional;
 public interface CompanyRepository extends JpaRepository<Company, Long> {
     Optional<Company> findByIdAndIsDeletedFalse(Long companyId);
 
-    Optional<Company> findByName(String companyName);
-
-    // 삭제되지 않은 회사 목록을 조회
     List<Company> findByIsDeletedFalse();
 
     Optional<Company> findByCompanyNumber(String companyNumber);
 
-    Optional<Company> findByIdAndIsDeletedTrue(Long id);
 }

--- a/src/main/java/com/soda/member/repository/MemberRepository.java
+++ b/src/main/java/com/soda/member/repository/MemberRepository.java
@@ -28,4 +28,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndIsDeletedFalse(String email);
 
     List<Member> findByIdInAndIsDeletedFalse(List<Long> memberIds);
+
+    List<Member> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/soda/member/repository/MemberRepository.java
+++ b/src/main/java/com/soda/member/repository/MemberRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +24,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 차후 QueryDSL로 리팩토링하면 좋음
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.memberProjects WHERE m.id = :id")
     Optional<Member> findWithProjectsById(@Param("id") Long id);
+
+    boolean existsByEmailAndIsDeletedFalse(String email);
+
+    List<Member> findByIdInAndIsDeletedFalse(List<Long> memberIds);
 }

--- a/src/main/java/com/soda/member/service/CompanyService.java
+++ b/src/main/java/com/soda/member/service/CompanyService.java
@@ -1,11 +1,10 @@
 package com.soda.member.service;
 
 
-import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.GeneralException;
 import com.soda.member.dto.company.CompanyCreateRequest;
-import com.soda.member.dto.company.CompanyUpdateRequest;
 import com.soda.member.dto.company.CompanyResponse;
+import com.soda.member.dto.company.CompanyUpdateRequest;
 import com.soda.member.dto.company.MemberResponse;
 import com.soda.member.entity.Company;
 import com.soda.member.error.CompanyErrorCode;
@@ -148,10 +147,16 @@ public class CompanyService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 활성 상태인 회사 엔티티 조회 (ID 기반, 내부 또는 다른 서비스에서 사용)
+     * @param companyId 회사 ID
+     * @return Company 엔티티
+     * @throws GeneralException 회사를 찾을 수 없거나 삭제된 경우 발생
+     */
     public Company getCompany(Long companyId) {
         return companyRepository.findByIdAndIsDeletedFalse(companyId)
                 .orElseThrow(() -> {
-                    log.error("회사 멤버 조회 실패: 회사를 찾을 수 없음 - {}", companyId);
+                    log.error("회사 조회 실패: ID {} 에 해당하는 활성 회사를 찾을 수 없음", companyId);
                     return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
                 });
     }

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -97,4 +97,19 @@ public class MemberService {
         memberRepository.save(member);
         log.info("멤버 정보 수정 성공: {}", member.getId());
     }
+
+
+    public Member getMemberWithProjectOrThrow(Long memberId) {
+        return memberRepository.findWithProjectsById(memberId)
+                .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    public boolean isAdmin(MemberRole memberRole) {
+        return memberRole == MemberRole.ADMIN;
+    }
+
+
+    public List<Member> findByIds(List<Long> ids) {
+        return null;
+    }
 }

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -1,21 +1,100 @@
 package com.soda.member.service;
 
 import com.soda.global.response.GeneralException;
+import com.soda.member.dto.MemberUpdateRequest;
+import com.soda.member.dto.SignupRequest;
+import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberRole;
+import com.soda.member.error.MemberErrorCode;
 import com.soda.member.repository.MemberRepository;
 import com.soda.project.error.ProjectErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional(readOnly = true)
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
+
     private final MemberRepository memberRepository;
 
     public Member findByIdAndIsDeletedFalse(Long memberId) {
         return memberRepository.findByIdAndIsDeletedFalse(memberId)
                 .orElseThrow(() -> new GeneralException(ProjectErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void saveMember(Member member) {
+        memberRepository.save(member);
+    }
+
+    public Member findMemberByAuthId(String authId) {
+        return memberRepository.findByAuthId(authId)
+                .orElseThrow(() -> {
+                    log.error("멤버 조회 실패: 잘못된 아이디 - {}", authId);
+                    return new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+                });
+    }
+
+    public Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.error("멤버 조회 실패: 이메일 없음 - {}", email);
+                    return new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+                });
+    }
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> {
+                    log.error("멤버 조회 실패: 멤버를 찾을 수 없음 - {}", memberId);
+                    return new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+                });
+    }
+
+    @Transactional
+    public void updateMemberPassword(Member member, String encodedPassword) {
+        member.changePassword(encodedPassword);
+        memberRepository.save(member);
+        log.info("멤버 비밀번호 변경 성공: {}", member.getAuthId());
+    }
+
+    public void validateDuplicateAuthId(String authId) {
+        if (memberRepository.existsByAuthId(authId)) {
+            log.error("회원 가입 실패: 아이디 중복 - {}", authId);
+            throw new GeneralException(MemberErrorCode.DUPLICATE_AUTH_ID);
+        }
+    }
+
+    public Member createMember(SignupRequest requestDto, Company company, PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .authId(requestDto.getAuthId())
+                .name(requestDto.getName())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .role(requestDto.getRole())
+                .company(company)
+                .position(requestDto.getPosition())
+                .phoneNumber(requestDto.getPhoneNumber())
+                .build();
+    }
+
+    public void validateEmailExists(String email) {
+        if (!memberRepository.existsByEmailAndIsDeletedFalse(email)) {
+            throw new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+        }
+    }
+
+    @Transactional
+    public void updateMember(Member member, MemberUpdateRequest request, Company company) {
+        member.updateMember(request, company);
+        memberRepository.save(member);
+        log.info("멤버 정보 수정 성공: {}", member.getId());
     }
 }

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -110,6 +110,6 @@ public class MemberService {
 
 
     public List<Member> findByIds(List<Long> ids) {
-        return null;
+        return memberRepository.findByIdIn(ids);
     }
 }

--- a/src/main/java/com/soda/project/service/StageService.java
+++ b/src/main/java/com/soda/project/service/StageService.java
@@ -32,6 +32,8 @@ public class StageService {
     private final StageRepository stageRepository;
     private final ProjectRepository projectRepository;
 
+    private final TaskService taskService;
+
     private static final float ORDER_INCREMENT = 1.0f;
     private static final float INITIAL_ORDER = 1.0f;
     private static final List<String> INITIAL_STAGE_NAMES = Arrays.asList(
@@ -151,6 +153,18 @@ public class StageService {
 
         log.info("단계 삭제 성공 (논리적): 단계 ID {}", stageId);
          stageRepository.save(stage);
+    }
+
+    private Stage validateStage(Long stageId, Project project) {
+        Stage stage = stageRepository.findById(stageId).orElseThrow(
+                ()-> new GeneralException(StageErrorCode.STAGE_NOT_FOUND)
+        );
+
+        if (!stage.getProject().equals(project)) {
+            throw new GeneralException(ProjectErrorCode.INVALID_STAGE_FOR_PROJECT);
+        }
+
+        return stage;
     }
 
     /**

--- a/src/main/java/com/soda/project/service/TaskService.java
+++ b/src/main/java/com/soda/project/service/TaskService.java
@@ -138,6 +138,9 @@ public class TaskService {
         log.info("태스크 삭제 성공 (논리적): {}", taskId);
     }
 
+    public Task getTaskOrThrow(Long taskId) {
+        return taskRepository.findById(taskId).orElseThrow(() -> new GeneralException(TaskErrorCode.TASK_NOT_FOUND));
+    }
 
     // --- Private Helper Methods ---
 
@@ -197,5 +200,9 @@ public class TaskService {
             log.info("스테이지 ID {} 에 첫 태스크 추가. 초기 순서 {} 적용", stageId, TASK_INITIAL_ORDER);
             return TASK_INITIAL_ORDER;
         }
+    }
+
+    private Task findById(Long taskId) {
+        return taskRepository.findById(taskId).orElseThrow(() -> new GeneralException(TaskErrorCode.TASK_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 요약
테스트 용이성을 높이고 "서비스당 레파지토리 하나" 원칙을 준수하기 위해 AuthService, MemberService, CompanyService 관련 코드를 리팩토링했습니다.

## 주요 변경 사항
- **AuthService 수정:**
    - **`MemberRepository` 직접 참조 제거:** 기존에 `MemberRepository`를 직접 사용하던 로직을 **`MemberService`를 호출**하는 방식으로 변경하여 "서비스당 레파지토리 하나" 원칙을 준수하도록 수정했습니다. 
    - 기존에 `CompanyRepository`를 직접 참조하던 로직을 `CompanyService` 호출 방식으로 변경했습니다.
    - 중복 로직을 분리하여 코드 가독성을 개선했습니다. 
- **MemberService 수정:**
    - `AuthService`에서 필요로 하는 회원 관련 조회/수정 로직을 처리하는 메소드를 추가했습니다.
    - `AuthService`에서 이관된 회원 정보 수정 기능을 포함하여 일반적인 회원 관리 책임을 담당합니다.
    - 다른 서비스(ProjectService 등)에서 Member 정보를 필요로 할 경우 사용할 수 있는 조회 메소드를 추가했습니다. 
- **CompanyService 리팩토링:**
    - Company 도메인 관련 로직에 집중하도록 수정하고, 다른 서비스에서 필요로 하는 조회 메소드를 추가했습니다. 
- **ErrorCode 추가:** 리팩토링 과정에서 필요한 ErrorCode를 추가했습니다. 

이번 리팩토링을 통해 각 서비스의 책임을 명확히 하고, 정해진 "서비스당 레파지토리 하나" 설계 원칙을 적용했습니다.

# 연관 이슈
- #69

# Pull Request 체크리스트

## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
