### PR TITLE
[Refact] 링크 전략패턴 생성 및 파일/링크 리팩토링

### DIFF
--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -5,6 +5,8 @@ import com.soda.article.service.ArticleService;
 import com.soda.common.file.dto.FileDeleteResponse;
 import com.soda.common.file.dto.FileUploadResponse;
 import com.soda.common.file.service.FileService;
+import com.soda.common.link.dto.LinkDeleteResponse;
+import com.soda.common.link.service.LinkService;
 import com.soda.global.response.ApiResponseForm;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class ArticleController {
 
     private final ArticleService articleService;
     private final FileService fileService;
+    private final LinkService linkService;
 
     @PostMapping("/articles")
     public ResponseEntity<ApiResponseForm<ArticleCreateResponse>> createArticle(@RequestBody ArticleCreateRequest request, HttpServletRequest user) {
@@ -84,4 +87,11 @@ public class ArticleController {
         return ResponseEntity.ok(ApiResponseForm.success(fileDeleteResponse));
     }
 
+    @DeleteMapping("articles/{articleId}/links/{linkId}")
+    public ResponseEntity<ApiResponseForm<?>> deleteLink(@PathVariable Long linkId,
+                                                         HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        LinkDeleteResponse linkDeleteResponse = linkService.delete("article", memberId, linkId);
+        return ResponseEntity.ok(ApiResponseForm.success(linkDeleteResponse));
+    }
 }

--- a/src/main/java/com/soda/article/domain/article/ArticleViewResponse.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleViewResponse.java
@@ -1,7 +1,6 @@
 package com.soda.article.domain.article;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.soda.article.domain.comment.CommentDTO;
 import com.soda.article.entity.Article;
 import com.soda.article.enums.PriorityType;
 import lombok.Builder;

--- a/src/main/java/com/soda/article/entity/ArticleLink.java
+++ b/src/main/java/com/soda/article/entity/ArticleLink.java
@@ -1,6 +1,6 @@
 package com.soda.article.entity;
 
-import com.soda.common.BaseEntity;
+import com.soda.common.link.model.LinkBase;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -13,11 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class ArticleLink extends BaseEntity {
-
-    private String urlAddress;
-
-    private String urlDescription;
+public class ArticleLink extends LinkBase {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id", nullable = false)
@@ -32,6 +28,11 @@ public class ArticleLink extends BaseEntity {
 
     public void delete() {
         this.markAsDeleted();
+    }
+
+    @Override
+    public Long getDomainId() {
+        return article.getId();
     }
 
     public void reActive() {

--- a/src/main/java/com/soda/article/error/ArticleErrorCode.java
+++ b/src/main/java/com/soda/article/error/ArticleErrorCode.java
@@ -8,8 +8,10 @@ public enum ArticleErrorCode implements ErrorCode {
     ARTICLE_ALREADY_DELETED("1102","This article is already deleted", HttpStatus.NOT_FOUND),
     INVALID_ARTICLE("1103", "The Article does not exist", HttpStatus.NOT_FOUND),
     PARENT_ARTICLE_NOT_FOUND("1104", "This parent article does not exist", HttpStatus.NOT_FOUND),
-    USER_NOT_UPLOAD_ARTICLE_FILE("1105", "This user does not upload article_file", HttpStatus.NOT_FOUND),
-    ;
+    ARTICLE_FILE_NOT_FOUND("1105", "This article file does not exist", HttpStatus.NOT_FOUND),
+    USER_NOT_UPLOAD_ARTICLE_FILE("1106", "This user does not upload article_file", HttpStatus.NOT_FOUND),
+    ARTICLE_LINK_NOT_FOUND("1107", "This link does not exist" , HttpStatus.NOT_FOUND ),
+    USER_NOT_UPLOAD_ARTICLE_LINK("1108", "This user does not upload article_link" , HttpStatus.NOT_FOUND ),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/article/repository/ArticleLinkRepository.java
+++ b/src/main/java/com/soda/article/repository/ArticleLinkRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface ArticleLinkRepository extends JpaRepository<ArticleLink, Long> {
     List<ArticleLink> findByArticleId(Long id);
 
-    Optional<ArticleLink> findByArticleIdAndUrlAddressAndIsDeletedTrue(Long articleId, String urlAddress);
+    Optional<ArticleLink> findByArticleIdAndUrlAddressAndIsDeletedTrue(Long articleId, String urladdress);
 }

--- a/src/main/java/com/soda/article/service/ArticleLinkService.java
+++ b/src/main/java/com/soda/article/service/ArticleLinkService.java
@@ -2,7 +2,6 @@ package com.soda.article.service;
 
 import com.soda.article.domain.article.ArticleLinkDTO;
 import com.soda.article.entity.Article;
-import com.soda.article.entity.ArticleFile;
 import com.soda.article.entity.ArticleLink;
 import com.soda.article.repository.ArticleLinkRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Transactional(readOnly = true)
 @Service

--- a/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
@@ -57,7 +57,7 @@ public class ArticleFileStrategy implements FileStrategy<Article, ArticleFile> {
     @Override
     public ArticleFile getFileOrThrow(Long fileId) {
         return articleFileRepository.findById(fileId)
-                .orElseThrow(() -> new GeneralException(ArticleErrorCode.INVALID_ARTICLE));
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.ARTICLE_FILE_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
@@ -50,6 +50,11 @@ public class ArticleFileStrategy implements FileStrategy<Article, ArticleFile> {
     }
 
     @Override
+    public List<ArticleFile> toEntities(List<String> url, List<String> names, Article domain) {
+        return List.of();
+    }
+
+    @Override
     public void saveAll(List<ArticleFile> entities) {
         articleFileRepository.saveAll(entities);
     }

--- a/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
@@ -50,6 +50,11 @@ public class ArticleLinkStrategy implements LinkStrategy<Article, ArticleLink> {
     }
 
     @Override
+    public List<ArticleLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Article domain) {
+        return List.of();
+    }
+
+    @Override
     public void saveAll(List<ArticleLink> entities) {
         articleLinkRepository.saveAll(entities);
     }
@@ -57,7 +62,7 @@ public class ArticleLinkStrategy implements LinkStrategy<Article, ArticleLink> {
     @Override
     public ArticleLink getLinkOrThrow(Long linkId) {
         return articleLinkRepository.findById(linkId)
-                .orElseThrow(() -> new GeneralException(ArticleErrorCode.ARTICLE_LINK_NOT_FOUND))
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.ARTICLE_LINK_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
@@ -1,0 +1,69 @@
+package com.soda.article.strategy;
+
+import com.soda.article.entity.Article;
+import com.soda.article.entity.ArticleLink;
+import com.soda.article.error.ArticleErrorCode;
+import com.soda.article.repository.ArticleLinkRepository;
+import com.soda.article.repository.ArticleRepository;
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.strategy.LinkStrategy;
+import com.soda.global.response.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleLinkStrategy implements LinkStrategy<Article, ArticleLink> {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleLinkRepository articleLinkRepository;
+
+    @Override
+    public String getSupportedDomain() {
+        return "article";
+    }
+
+    @Override
+    public Article getDomainOrThrow(Long domainId) {
+        return articleRepository.findById(domainId)
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.INVALID_ARTICLE));
+    }
+
+    @Override
+    public void validateWriter(Long memberId, Article article) {
+        if (!article.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ArticleErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Override
+    public ArticleLink toEntity(LinkUploadRequest.LinkUploadDTO dto, Article article) {
+        return ArticleLink.builder()
+                .urlAddress(dto.getUrlAddress())
+                .urlDescription(dto.getUrlDescription())
+                .article(article)
+                .build();
+    }
+
+    @Override
+    public void saveAll(List<ArticleLink> entities) {
+        articleLinkRepository.saveAll(entities);
+    }
+
+    @Override
+    public ArticleLink getLinkOrThrow(Long linkId) {
+        return articleLinkRepository.findById(linkId)
+                .orElseThrow(() -> new GeneralException(ArticleErrorCode.ARTICLE_LINK_NOT_FOUND))
+    }
+
+    @Override
+    public void validateLinkUploader(Long memberId, ArticleLink link) {
+        if (!link.getArticle().getMember().getId().equals(memberId)) {
+            throw new GeneralException(ArticleErrorCode.USER_NOT_UPLOAD_ARTICLE_LINK);
+        }
+    }
+}

--- a/src/main/java/com/soda/common/file/service/FileService.java
+++ b/src/main/java/com/soda/common/file/service/FileService.java
@@ -6,6 +6,7 @@ import com.soda.common.file.error.FileErrorCode;
 import com.soda.common.file.model.FileBase;
 import com.soda.common.file.strategy.FileStrategy;
 import com.soda.global.response.GeneralException;
+import com.soda.request.entity.RequestFile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -56,6 +57,13 @@ public class FileService {
         file.delete();
 
         return FileDeleteResponse.fromEntity(file);
+    }
+
+    public List<RequestFile> buildFiles(String domainType, Object domain, List<MultipartFile> files) {
+        FileStrategy strategy = getStrategy(domainType);
+        List<String> urls = s3Service.uploadFiles(files);
+        List<String> names = files.stream().map(MultipartFile::getOriginalFilename).collect(Collectors.toList());
+        return strategy.toEntities(urls, names, domain);
     }
 
     private FileStrategy getStrategy(String domainType) {

--- a/src/main/java/com/soda/common/file/strategy/FileStrategy.java
+++ b/src/main/java/com/soda/common/file/strategy/FileStrategy.java
@@ -14,6 +14,8 @@ public interface FileStrategy<T, E extends FileBase> {
 
     E toEntity(MultipartFile file, String url, T domain);
 
+    List<E> toEntities(List<String> url, List<String> names, T domain);
+
     void saveAll(List<E> entities);
 
     E getFileOrThrow(Long fileId);

--- a/src/main/java/com/soda/common/link/dto/LinkDeleteResponse.java
+++ b/src/main/java/com/soda/common/link/dto/LinkDeleteResponse.java
@@ -6,16 +6,20 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class LinkDTO {
+public class LinkDeleteResponse {
     private Long id;
+    private Long domainId;
     private String urlAddress;
     private String urlDescription;
+    private Boolean isDeleted;
 
-    public static <T extends LinkBase> LinkDTO fromEntity(T link) {
-        return LinkDTO.builder()
+    public static <T extends LinkBase> LinkDeleteResponse fromEntity(T link) {
+        return LinkDeleteResponse.builder()
                 .id(link.getId())
+                .domainId(link.getDomainId())
                 .urlAddress(link.getUrlAddress())
                 .urlDescription(link.getUrlDescription())
+                .isDeleted(link.getIsDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/soda/common/link/dto/LinkUploadRequest.java
+++ b/src/main/java/com/soda/common/link/dto/LinkUploadRequest.java
@@ -1,0 +1,16 @@
+package com.soda.common.link.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class LinkUploadRequest {
+    private List<LinkUploadDTO> links;
+
+    @Getter
+    public static class LinkUploadDTO {
+        private String urlAddress;
+        private String urlDescription;
+    }
+}

--- a/src/main/java/com/soda/common/link/dto/LinkUploadResponse.java
+++ b/src/main/java/com/soda/common/link/dto/LinkUploadResponse.java
@@ -1,0 +1,36 @@
+package com.soda.common.link.dto;
+
+import com.soda.common.link.error.LinkErrorCode;
+import com.soda.common.link.model.LinkBase;
+import com.soda.global.response.GeneralException;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class LinkUploadResponse {
+    private Long domainId;
+    private List<LinkDTO> links;
+
+    public static <T extends LinkBase> LinkUploadResponse fromEntity(List<T> links) {
+        if (links == null || links.isEmpty()) {
+            throw new GeneralException(LinkErrorCode.FILE_LIST_EMPTY);
+        }
+
+        Long domainId = links.get(0).getDomainId();
+        List<LinkDTO> linkDTOs = links.stream()
+                .map(link -> LinkDTO.builder()
+                        .urlAddress(link.getUrlAddress())
+                        .urlDescription(link.getUrlDescription())
+                        .build())
+                .collect(Collectors.toList());
+
+        return LinkUploadResponse.builder()
+                .domainId(domainId)
+                .links(linkDTOs)
+                .build();
+    }
+}

--- a/src/main/java/com/soda/common/link/error/LinkErrorCode.java
+++ b/src/main/java/com/soda/common/link/error/LinkErrorCode.java
@@ -1,0 +1,35 @@
+package com.soda.common.link.error;
+
+import com.soda.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum LinkErrorCode implements ErrorCode {
+    LINK_DOMAIN_NOT_FOUND("3301", "The domain on this file does not exist", HttpStatus.NOT_FOUND),
+    FILE_LIST_EMPTY("3302", "The file list is empty" , HttpStatus.BAD_REQUEST ),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    LinkErrorCode (String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/soda/common/link/model/LinkBase.java
+++ b/src/main/java/com/soda/common/link/model/LinkBase.java
@@ -17,8 +17,9 @@ public abstract class LinkBase extends BaseEntity {
 
     protected String urlDescription;
 
-    public LinkBase(String urlAddress, String urlDescription) {
-        this.urlAddress = urlAddress;
-        this.urlDescription = urlDescription;
+    public void delete() {
+        markAsDeleted();
     }
+
+    public abstract Long getDomainId();
 }

--- a/src/main/java/com/soda/common/link/service/LinkService.java
+++ b/src/main/java/com/soda/common/link/service/LinkService.java
@@ -1,0 +1,63 @@
+package com.soda.common.link.service;
+
+import com.soda.common.link.dto.LinkDeleteResponse;
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.dto.LinkUploadResponse;
+import com.soda.common.link.error.LinkErrorCode;
+import com.soda.common.link.model.LinkBase;
+import com.soda.common.link.strategy.LinkStrategy;
+import com.soda.global.response.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class LinkService {
+
+    private final Map<String, LinkStrategy> strategies;
+
+    public LinkService(List<LinkStrategy> strategies) {
+        this.strategies = strategies.stream()
+                .collect(Collectors.toMap(LinkStrategy::getSupportedDomain, Function.identity()));
+    }
+
+    @Transactional
+    public LinkUploadResponse upload(String domainType, Long domainId, Long memberId, LinkUploadRequest linkUploadRequest) {
+        LinkStrategy strategy = getStrategy(domainType);
+
+        Object domain = strategy.getDomainOrThrow(domainId);
+        strategy.validateWriter(memberId, domain);
+
+        List<LinkBase> entities = linkUploadRequest.getLinks().stream()
+                .map(dto -> strategy.toEntity(dto, domain))
+                .collect(Collectors.toList());
+
+        strategy.saveAll(entities);
+        return LinkUploadResponse.fromEntity(entities);
+    }
+
+    @Transactional
+    public LinkDeleteResponse delete(String domainType, Long linkId, Long memberId) {
+        LinkStrategy strategy = getStrategy(domainType);
+
+        LinkBase link = strategy.getLinkOrThrow(linkId);
+        strategy.validateLinkUploader(memberId, link);
+
+        link.delete();
+
+        return LinkDeleteResponse.fromEntity(link);
+    }
+
+    private LinkStrategy getStrategy(String domainType) {
+        LinkStrategy strategy = strategies.get(domainType.toLowerCase());
+        if (strategy == null) {
+            throw new GeneralException(LinkErrorCode.LINK_DOMAIN_NOT_FOUND);
+        }
+        return strategy;
+    }
+}

--- a/src/main/java/com/soda/common/link/service/LinkService.java
+++ b/src/main/java/com/soda/common/link/service/LinkService.java
@@ -53,6 +53,12 @@ public class LinkService {
         return LinkDeleteResponse.fromEntity(link);
     }
 
+    @Transactional
+    public <T extends LinkBase> List<T> buildLinks(String domainType, Object domain, List<? extends LinkUploadRequest.LinkUploadDTO> dtos) {
+        LinkStrategy strategy = getStrategy(domainType);
+        return (List<T>) strategy.toEntities(dtos, domain);
+    }
+
     private LinkStrategy getStrategy(String domainType) {
         LinkStrategy strategy = strategies.get(domainType.toLowerCase());
         if (strategy == null) {

--- a/src/main/java/com/soda/common/link/strategy/LinkStrategy.java
+++ b/src/main/java/com/soda/common/link/strategy/LinkStrategy.java
@@ -14,6 +14,8 @@ public interface LinkStrategy<T, E extends LinkBase> {
 
     E toEntity(LinkUploadRequest.LinkUploadDTO dto, T domain);
 
+    List<E> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, T domain);
+
     void saveAll(List<E> entities);
 
     E getLinkOrThrow(Long linkId);

--- a/src/main/java/com/soda/common/link/strategy/LinkStrategy.java
+++ b/src/main/java/com/soda/common/link/strategy/LinkStrategy.java
@@ -1,0 +1,22 @@
+package com.soda.common.link.strategy;
+
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.model.LinkBase;
+
+import java.util.List;
+
+public interface LinkStrategy<T, E extends LinkBase> {
+    String getSupportedDomain();
+
+    T getDomainOrThrow(Long domainId);
+
+    void validateWriter(Long memberId, T domain);
+
+    E toEntity(LinkUploadRequest.LinkUploadDTO dto, T domain);
+
+    void saveAll(List<E> entities);
+
+    E getLinkOrThrow(Long linkId);
+
+    void validateLinkUploader(Long memberId, E link);
+}

--- a/src/main/java/com/soda/global/request/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/soda/global/request/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,30 @@
+package com.soda.global.request;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected  boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/soda/member/dto/company/CompanyCreateRequest.java
+++ b/src/main/java/com/soda/member/dto/company/CompanyCreateRequest.java
@@ -10,5 +10,5 @@ public class CompanyCreateRequest {
     private String phoneNumber;
     private String companyNumber;
     private String address;
-    private String detailAddress;
+    private String detailaddress;
 }

--- a/src/main/java/com/soda/member/service/CompanyService.java
+++ b/src/main/java/com/soda/member/service/CompanyService.java
@@ -45,7 +45,7 @@ public class CompanyService {
                 .phoneNumber(request.getPhoneNumber())
                 .companyNumber(request.getCompanyNumber())
                 .address(request.getAddress())
-                .detailAddress(request.getDetailAddress())
+                .detailAddress(request.getDetailaddress())
                 .build();
 
         Company savedCompany = companyRepository.save(company);

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -12,6 +12,7 @@ import com.soda.request.dto.request.*;
 import com.soda.request.service.RequestService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,11 +26,13 @@ public class RequestController {
     private final FileService fileService;
     private final LinkService linkService;
 
-    @PostMapping("/requests")
-    public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestBody RequestCreateRequest requestCreateRequest,
+
+    @PostMapping(value = "/requests", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestPart("data") RequestCreateRequest requestCreateRequest,
+                                                            @RequestPart(value = "file", required = false) List<MultipartFile> files,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest);
+        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest, files);
         return ResponseEntity.ok(ApiResponseForm.success(requestCreateResponse));
     }
 

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -49,11 +49,12 @@ public class RequestController {
     }
 
     @PutMapping("/requests/{requestId}")
-    public ResponseEntity<ApiResponseForm<?>> updateRequest(@RequestBody RequestUpdateRequest requestUpdateRequest,
+    public ResponseEntity<ApiResponseForm<?>> updateRequest(@RequestPart("data") RequestUpdateRequest requestUpdateRequest,
+                                                            @RequestPart(value = "file", required = false) List<MultipartFile> files,
                                                             @PathVariable Long requestId,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestUpdateResponse requestUpdateResponse = requestService.updateRequest(memberId, requestId, requestUpdateRequest);
+        RequestUpdateResponse requestUpdateResponse = requestService.updateRequest(memberId, requestId, requestUpdateRequest, files);
         return ResponseEntity.ok(ApiResponseForm.success(requestUpdateResponse));
     }
 

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -1,9 +1,13 @@
 package com.soda.request.controller;
 
-import com.soda.common.file.service.FileService;
-import com.soda.global.response.ApiResponseForm;
 import com.soda.common.file.dto.FileDeleteResponse;
 import com.soda.common.file.dto.FileUploadResponse;
+import com.soda.common.file.service.FileService;
+import com.soda.common.link.dto.LinkDeleteResponse;
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.dto.LinkUploadResponse;
+import com.soda.common.link.service.LinkService;
+import com.soda.global.response.ApiResponseForm;
 import com.soda.request.dto.request.*;
 import com.soda.request.service.RequestService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +23,7 @@ import java.util.List;
 public class RequestController {
     private final RequestService requestService;
     private final FileService fileService;
+    private final LinkService linkService;
 
     @PostMapping("/requests")
     public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestBody RequestCreateRequest requestCreateRequest,
@@ -72,5 +77,22 @@ public class RequestController {
         Long memberId = (Long) request.getAttribute("memberId");
         FileDeleteResponse fileDeleteResponse = fileService.delete("request", memberId, fileId);
         return ResponseEntity.ok(ApiResponseForm.success(fileDeleteResponse));
+    }
+
+    @PostMapping("/requests/{requestId}/links")
+    public ResponseEntity<ApiResponseForm<?>> uploadLinks(@PathVariable Long requestId,
+                                                          @RequestBody LinkUploadRequest requestLinkUploadRequest,
+                                                          HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        LinkUploadResponse linkUploadResponse = linkService.upload("request", requestId, memberId, requestLinkUploadRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(linkUploadResponse));
+    }
+
+    @DeleteMapping("requests/{requestId}/links/{linkId}")
+    public ResponseEntity<ApiResponseForm<?>> deleteLink(@PathVariable Long linkId,
+                                                         HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        LinkDeleteResponse linkDeleteResponse = linkService.delete("request", memberId, linkId);
+        return ResponseEntity.ok(ApiResponseForm.success(linkDeleteResponse));
     }
 }

--- a/src/main/java/com/soda/request/controller/ResponseController.java
+++ b/src/main/java/com/soda/request/controller/ResponseController.java
@@ -87,7 +87,7 @@ public class ResponseController {
         return ResponseEntity.ok(ApiResponseForm.success(fileDeleteResponse));
     }
 
-    @DeleteMapping("requests/{requestId}/links/{linkId}")
+    @DeleteMapping("responses/{responseId}/links/{linkId}")
     public ResponseEntity<ApiResponseForm<?>> deleteLink(@PathVariable Long linkId,
                                                          HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");

--- a/src/main/java/com/soda/request/controller/ResponseController.java
+++ b/src/main/java/com/soda/request/controller/ResponseController.java
@@ -3,6 +3,8 @@ package com.soda.request.controller;
 import com.soda.common.file.dto.FileDeleteResponse;
 import com.soda.common.file.dto.FileUploadResponse;
 import com.soda.common.file.service.FileService;
+import com.soda.common.link.dto.LinkDeleteResponse;
+import com.soda.common.link.service.LinkService;
 import com.soda.global.response.ApiResponseForm;
 import com.soda.request.dto.response.*;
 import com.soda.request.service.ResponseService;
@@ -19,6 +21,7 @@ import java.util.List;
 public class ResponseController {
     private final ResponseService responseService;
     private final FileService fileService;
+    private final LinkService linkService;
 
     @PostMapping("/requests/{requestId}/approval")
     public ResponseEntity<ApiResponseForm<?>> approveRequest(@RequestBody RequestApproveRequest requestApproveRequest,
@@ -82,5 +85,13 @@ public class ResponseController {
         Long memberId = (Long) request.getAttribute("memberId");
         FileDeleteResponse fileDeleteResponse = fileService.delete("response", memberId, fileId);
         return ResponseEntity.ok(ApiResponseForm.success(fileDeleteResponse));
+    }
+
+    @DeleteMapping("requests/{requestId}/links/{linkId}")
+    public ResponseEntity<ApiResponseForm<?>> deleteLink(@PathVariable Long linkId,
+                                                         HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        LinkDeleteResponse linkDeleteResponse = linkService.delete("response", memberId, linkId);
+        return ResponseEntity.ok(ApiResponseForm.success(linkDeleteResponse));
     }
 }

--- a/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
@@ -1,16 +1,18 @@
 package com.soda.request.dto.request;
 
-import com.soda.common.link.dto.LinkDTO;
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 public class RequestCreateRequest {
     private String title;
     private String content;
     private Long projectId;
     private Long stageId;
     private Long taskId;
-    private List<LinkDTO> links;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
 }

--- a/src/main/java/com/soda/request/dto/request/RequestUpdateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.soda.request.dto.request;
 
-import com.soda.common.link.dto.LinkDTO;
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,5 +9,11 @@ import java.util.List;
 public class RequestUpdateRequest {
     private String title;
     private String content;
-    private List<LinkDTO> links;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
+
+    @Getter
+    public static class LinkUploadDTO {
+        private String urlAddress;
+        private String urlDescription;
+    }
 }

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -63,13 +63,16 @@ public class Request extends BaseEntity {
         this.content = content;
     }
     public void addLinks(List<RequestLink> newLinks) {
-        if ( this.links == null ) {
+        if (this.links == null) {
             this.links = new ArrayList<>();
         }
-        for (RequestLink link : newLinks) {
-            link.updateRequest(this);
-            this.links.add(link);
+        this.links.addAll(newLinks);
+    }
+    public void addFiles(List<RequestFile> newFiles) {
+        if (this.files == null) {
+            this.files = new ArrayList<>();
         }
+        this.files.addAll(newFiles);
     }
 
     public void delete() {

--- a/src/main/java/com/soda/request/entity/RequestLink.java
+++ b/src/main/java/com/soda/request/entity/RequestLink.java
@@ -15,10 +15,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestLink extends LinkBase {
 
-    private String urlAddress;
-
-    private String urlDescription;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "request_id", nullable = false)
     private Request request;
@@ -32,5 +28,10 @@ public class RequestLink extends LinkBase {
 
     public void updateRequest(Request request) {
         this.request = request;
+    }
+
+    @Override
+    public Long getDomainId() {
+        return request.getId();
     }
 }

--- a/src/main/java/com/soda/request/entity/ResponseLink.java
+++ b/src/main/java/com/soda/request/entity/ResponseLink.java
@@ -29,4 +29,9 @@ public class ResponseLink extends LinkBase {
     public void updateResponse(Response response) {
         this.response = response;
     }
+
+    @Override
+    public Long getDomainId() {
+        return this.response.getId();
+    }
 }

--- a/src/main/java/com/soda/request/error/RequestErrorCode.java
+++ b/src/main/java/com/soda/request/error/RequestErrorCode.java
@@ -6,8 +6,10 @@ import org.springframework.http.HttpStatus;
 public enum RequestErrorCode implements ErrorCode {
     REQUEST_NOT_FOUND("3001", "This request id is not found in Requests", HttpStatus.NOT_FOUND),
     USER_NOT_WRITE_REQUEST("3002", "This user doesn't write this request", HttpStatus.BAD_REQUEST),
-    REQUESTFILE_NOT_FOUND("3003", "This request_file is not found", HttpStatus.NOT_FOUND),
+    REQUEST_FILE_NOT_FOUND("3003", "This request_file is not found", HttpStatus.NOT_FOUND),
     USER_NOT_UPLOAD_FILE("3004", "This user didn't upload the request_file", HttpStatus.BAD_REQUEST),
+    REQUEST_LINK_NOT_FOUND("3005", "This request_link is not found" , HttpStatus.NOT_FOUND ),
+    USER_NOT_UPLOAD_LINK("3006", "This user didn't upload the request_link" , HttpStatus.BAD_REQUEST ),
     ;
 
     private final String code;

--- a/src/main/java/com/soda/request/error/ResponseErrorCode.java
+++ b/src/main/java/com/soda/request/error/ResponseErrorCode.java
@@ -7,7 +7,9 @@ public enum ResponseErrorCode implements ErrorCode {
     RESPONSE_NOT_FOUND("3101", "This response id is not found in Requests", HttpStatus.NOT_FOUND),
     USER_NOT_WRITE_RESPONSE("3102", "This user didn't write the response", HttpStatus.UNAUTHORIZED),
     RESPONSE_FILE_NOT_FOUND("3103", "This response_file is not found" , HttpStatus.NOT_FOUND),
-    USER_NOT_UPLOAD_FILE("3104", "This user didn't upload the response_file" , HttpStatus.UNAUTHORIZED ),;
+    USER_NOT_UPLOAD_FILE("3104", "This user didn't upload the response_file" , HttpStatus.UNAUTHORIZED ),
+    RESPONSE_LINK_NOT_FOUND("3105", "This response link is not found" , HttpStatus.NOT_FOUND ),
+    USER_NOT_UPLOAD_LINK("3106", "This user didn't upload the response_link" , HttpStatus.UNAUTHORIZED ),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/request/repository/RequestLinkRepository.java
+++ b/src/main/java/com/soda/request/repository/RequestLinkRepository.java
@@ -1,0 +1,9 @@
+package com.soda.request.repository;
+
+import com.soda.request.entity.RequestLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RequestLinkRepository extends JpaRepository<RequestLink, Long> {
+}

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -173,7 +173,7 @@ public class RequestService {
         Request request = buildRequest(dto, member, task);
         List<RequestLink> requestLinks = linkService.buildLinks("request", request, dto.getLinks());
         request.addLinks(requestLinks);
-        List<RequestFile> requestFiles = buildRequestFiles(files, request);
+        List<RequestFile> requestFiles = fileService.buildFiles("request", request, files);
         request.addFiles(requestFiles);
         return requestRepository.save(request);
     }

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -73,14 +73,14 @@ public class RequestService {
 
 
     @Transactional
-    public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest) throws GeneralException {
+    public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest, List<MultipartFile> files) throws GeneralException {
         Request request = getRequestOrThrow(requestId);
 
         // update요청을 한 member가 승인요청을 작성했던 member인지 확인
         validateRequestWriter(memberId, request);
 
         // request의 제목, 내용을 수정
-        updateRequestFields(requestUpdateRequest, request);
+        updateRequestFields(requestUpdateRequest, files, request);
 
         requestRepository.save(request);
         requestRepository.flush();
@@ -157,7 +157,7 @@ public class RequestService {
     }
 
     // Request(승인요청)의 제목이나 내용을 수정하는 메서드
-    private void updateRequestFields(RequestUpdateRequest requestUpdateRequest, Request request) {
+    private void updateRequestFields(RequestUpdateRequest requestUpdateRequest, List<MultipartFile> files, Request request) {
         if(requestUpdateRequest.getTitle() != null) {
             request.updateTitle(requestUpdateRequest.getTitle());
         }
@@ -166,6 +166,9 @@ public class RequestService {
         }
         if(requestUpdateRequest.getLinks() != null) {
             request.addLinks(linkService.buildLinks("request", request, requestUpdateRequest.getLinks()));
+        }
+        if(files != null) {
+            request.addFiles(fileService.buildFiles("request", request, files));
         }
     }
 

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -48,8 +48,6 @@ public class RequestService {
     @Transactional
     public RequestCreateResponse createRequest(Long memberId, RequestCreateRequest requestCreateRequest, List<MultipartFile> files) {
         Member member = getMemberWithProjectOrThrow(memberId);
-        System.out.println(requestCreateRequest);
-        System.out.println(requestCreateRequest.getTaskId());
         Task task = getTaskOrThrow(requestCreateRequest.getTaskId());
 
         // 현재 프로젝트에 속한 "개발사"의 멤버가 아니고, 어드민도 아니면 USER_NOT_IN_PROJECT_DEV 반환

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -177,13 +177,17 @@ public class RequestService {
     }
 
     private List<RequestLink> buildRequestLinks(List<LinkDTO> linkDTOs) {
-        if (linkDTOs == null) return List.of();
+        if (linkDTOs == null) {
+            return List.of();
+        }
 
         return linkDTOs.stream()
-                .map(dto -> RequestLink.builder()
-                        .urlAddress(dto.getUrlAddress())
-                        .urlDescription(dto.getUrlDescription())
-                        .build())
+                .map(dto -> {
+                    return RequestLink.builder()
+                            .urlAddress(dto.getUrlAddress())
+                            .urlDescription(dto.getUrlDescription())
+                            .build();
+                })
                 .toList();
     }
 }

--- a/src/main/java/com/soda/request/strategy/RequestFileStrategy.java
+++ b/src/main/java/com/soda/request/strategy/RequestFileStrategy.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional
@@ -47,6 +48,21 @@ public class RequestFileStrategy implements FileStrategy<Request, RequestFile> {
                 .url(url)
                 .request(request)
                 .build();
+    }
+
+    @Override
+    public List<RequestFile> toEntities(List<String> urls, List<String> names, Request domain) {
+        if (urls == null || urls.isEmpty()) {
+            return List.of();
+        }
+
+        return IntStream.range(0, urls.size())
+                .mapToObj(i -> RequestFile.builder()
+                        .url(urls.get(i))
+                        .name(names.get(i))
+                        .request(domain)
+                        .build())
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
@@ -1,26 +1,27 @@
 package com.soda.request.strategy;
 
-import com.soda.common.file.strategy.FileStrategy;
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.strategy.LinkStrategy;
 import com.soda.global.response.GeneralException;
 import com.soda.request.entity.Request;
-import com.soda.request.entity.RequestFile;
+import com.soda.request.entity.RequestLink;
 import com.soda.request.error.RequestErrorCode;
-import com.soda.request.repository.RequestFileRepository;
+import com.soda.request.repository.RequestLinkRepository;
 import com.soda.request.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class RequestFileStrategy implements FileStrategy<Request, RequestFile> {
+public class RequestLinkStrategy implements LinkStrategy<Request, RequestLink> {
 
     private final RequestRepository requestRepository;
-    private final RequestFileRepository requestFileRepository;
+    private final RequestLinkRepository requestLinkRepository;
+
 
     @Override
     public String getSupportedDomain() {
@@ -41,29 +42,29 @@ public class RequestFileStrategy implements FileStrategy<Request, RequestFile> {
     }
 
     @Override
-    public RequestFile toEntity(MultipartFile file, String url, Request request) {
-        return RequestFile.builder()
-                .name(file.getOriginalFilename())
-                .url(url)
+    public RequestLink toEntity(LinkUploadRequest.LinkUploadDTO dto, Request request) {
+        return RequestLink.builder()
+                .urlAddress(dto.getUrlAddress())
+                .urlDescription(dto.getUrlDescription())
                 .request(request)
                 .build();
     }
 
     @Override
-    public void saveAll(List<RequestFile> entities) {
-        requestFileRepository.saveAll(entities);
+    public void saveAll(List<RequestLink> entities) {
+        requestLinkRepository.saveAll(entities);
     }
 
     @Override
-    public RequestFile getFileOrThrow(Long fileId) {
-        return requestFileRepository.findById(fileId)
-                .orElseThrow(() -> new GeneralException(RequestErrorCode.REQUEST_FILE_NOT_FOUND));
+    public RequestLink getLinkOrThrow(Long linkId) {
+        return requestLinkRepository.findById(linkId)
+                .orElseThrow(() -> new GeneralException(RequestErrorCode.REQUEST_LINK_NOT_FOUND));
     }
 
     @Override
-    public void validateFileUploader(Long memberId, RequestFile file) {
-        if (!file.getRequest().getMember().getId().equals(memberId)) {
-            throw new GeneralException(RequestErrorCode.USER_NOT_UPLOAD_FILE);
+    public void validateLinkUploader(Long memberId, RequestLink link) {
+        if (!link.getRequest().getMember().getId().equals(memberId)) {
+            throw new GeneralException(RequestErrorCode.USER_NOT_UPLOAD_LINK);
         }
     }
 }

--- a/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
@@ -50,6 +50,20 @@ public class RequestLinkStrategy implements LinkStrategy<Request, RequestLink> {
                 .build();
     }
 
+    public List<RequestLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Request request) {
+        if (dtos == null) {
+            return List.of();
+        }
+
+        return dtos.stream()
+                .map(dto -> RequestLink.builder()
+                        .urlAddress(dto.getUrlAddress())
+                        .urlDescription(dto.getUrlDescription())
+                        .request(request)
+                        .build())
+                .toList();
+    }
+
     @Override
     public void saveAll(List<RequestLink> entities) {
         requestLinkRepository.saveAll(entities);

--- a/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/RequestLinkStrategy.java
@@ -51,7 +51,7 @@ public class RequestLinkStrategy implements LinkStrategy<Request, RequestLink> {
     }
 
     public List<RequestLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Request request) {
-        if (dtos == null) {
+        if (dtos == null || dtos.isEmpty()) {
             return List.of();
         }
 

--- a/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
@@ -50,6 +50,11 @@ public class ResponseFileStrategy implements FileStrategy<Response, ResponseFile
     }
 
     @Override
+    public List<ResponseFile> toEntities(List<String> url, List<String> names, Response domain) {
+        return List.of();
+    }
+
+    @Override
     public void saveAll(List<ResponseFile> entities) {
         responseFileRepository.saveAll(entities);
     }

--- a/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
@@ -51,6 +51,11 @@ public class ResponseLinkStrategy implements LinkStrategy<Response, ResponseLink
     }
 
     @Override
+    public List<ResponseLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Response domain) {
+        return List.of();
+    }
+
+    @Override
     public void saveAll(List<ResponseLink> entities) {
         responseLinkRepository.saveAll(entities);
     }

--- a/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
@@ -1,0 +1,70 @@
+package com.soda.request.strategy;
+
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.strategy.LinkStrategy;
+import com.soda.global.response.GeneralException;
+import com.soda.request.entity.Response;
+import com.soda.request.entity.ResponseLink;
+import com.soda.request.error.ResponseErrorCode;
+import com.soda.request.repository.ResponseLinkRepository;
+import com.soda.request.repository.ResponseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResponseLinkStrategy implements LinkStrategy<Response, ResponseLink> {
+
+    private final ResponseRepository responseRepository;
+    private final ResponseLinkRepository responseLinkRepository;
+
+
+    @Override
+    public String getSupportedDomain() {
+        return "response";
+    }
+
+    @Override
+    public Response getDomainOrThrow(Long domainId) {
+        return responseRepository.findById(domainId)
+                .orElseThrow(() -> new GeneralException(ResponseErrorCode.RESPONSE_NOT_FOUND));
+    }
+
+    @Override
+    public void validateWriter(Long memberId, Response response) {
+        if (!response.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ResponseErrorCode.USER_NOT_WRITE_RESPONSE);
+        }
+    }
+
+    @Override
+    public ResponseLink toEntity(LinkUploadRequest.LinkUploadDTO dto, Response response) {
+        return ResponseLink.builder()
+                .urlAddress(dto.getUrlAddress())
+                .urlDescription(dto.getUrlDescription())
+                .response(response)
+                .build();
+    }
+
+    @Override
+    public void saveAll(List<ResponseLink> entities) {
+        responseLinkRepository.saveAll(entities);
+    }
+
+    @Override
+    public ResponseLink getLinkOrThrow(Long linkId) {
+        return responseLinkRepository.findById(linkId)
+                .orElseThrow(() -> new GeneralException(ResponseErrorCode.RESPONSE_LINK_NOT_FOUND));
+    }
+
+    @Override
+    public void validateLinkUploader(Long memberId, ResponseLink link) {
+        if (!link.getResponse().getMember().getId().equals(memberId)) {
+            throw new GeneralException(ResponseErrorCode.USER_NOT_UPLOAD_LINK);
+        }
+    }
+}


### PR DESCRIPTION

# 요약
- Link 전략패턴 생성
- RequestFile, RequestLink에서 쓰이던 메서드를 File, Link 도메인으로 옮겼음


# 연관 이슈
#56 

# 변경사항
- 기존에는 LinkBase만 각 도메인의 Link가 상속받아 사용하고 Link관련 메서드들은 각 도메인에서 쌩으로 구현했었음.
  - Link에 대한 전략패턴을 생성해 각 도메인에서 공통으로 사용되지만 도메인 성격에 따라 다른 부분이 있는 메서드를 LinkStrategy에 인터페이스로 정의하고 LinkService에서 LinkStrategy에서 정의된 메서드를 활용해 메서드 작성 
- File, Link에서 전략패턴을 사용하지 않고 쌩으로 구현하던 메서드들을 전략으로 등록함

# 확인해야할 사항
- Article, Request, Response 생성할때는 글/요청/응답, 파일, 링크 한 번에 생성
Article, Request, Response 수정할때는 글/요청/응답, 파일, 링크 한 번에 추가 가능, 삭제는 개별 api호출, 수정은 불가
  - 위 case에 맞춰서 개발하였습니다
  - 우선 Request에 대해서만 작업 완료하였습니다
  - 이 PR이후에 나머지 도메인에 대해 작업할 예정입니다. 