### PR TITLE
[Refact] 파일 업로드 분리

### DIFF
--- a/src/main/java/com/soda/article/domain/article/ArticleCreateRequest.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleCreateRequest.java
@@ -25,7 +25,6 @@ public class ArticleCreateRequest {
     private Long memberId;
     private Long stageId;
     private Long parentArticleId;           // 답글인 경우 필요함
-    private List<ArticleFileDTO> fileList;
     private List<ArticleLinkDTO> linkList;
 
     public Article toEntity(Member member, Stage stage, Article parentArticle) {

--- a/src/main/java/com/soda/article/domain/article/ArticleModifyRequest.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleModifyRequest.java
@@ -20,7 +20,6 @@ public class ArticleModifyRequest {
     private LocalDateTime deadLine;
     private Long memberId;
     private Long stageId;
-    private List<ArticleFileDTO> fileList;
     private List<ArticleLinkDTO> linkList;
 
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -58,15 +58,16 @@ public class ArticleService {
                     .orElseThrow(() -> new GeneralException(ArticleErrorCode.PARENT_ARTICLE_NOT_FOUND));
         }
 
-        articleFileService.validateFileSize(request.getFileList());
+//        articleFileService.validateFileSize(request.getFileList());
         articleLinkService.validateLinkSize(request.getLinkList());
 
         Article article = request.toEntity(member, stage, parentArticle);
         article = articleRepository.save(article);
 
         // file & link 저장
-        articleFileService.processFiles(request.getFileList(), article);
+//        articleFileService.processFiles(request.getFileList(), article);
         articleLinkService.processLinks(request.getLinkList(), article);
+
 
         return ArticleCreateResponse.fromEntity(article);
     }
@@ -89,17 +90,17 @@ public class ArticleService {
 
         Article article = validateArticle(articleId);
 
-        articleFileService.validateFileSize(request.getFileList());
+//        articleFileService.validateFileSize(request.getFileList());
         articleLinkService.validateLinkSize(request.getLinkList());
 
         article.updateArticle(request.getTitle(), request.getContent(), request.getPriority(), request.getDeadLine());
 
         // 기존 파일 및 링크 삭제
-        articleFileService.deleteFiles(articleId, article);
-        articleLinkService.deleteLinks(articleId, article);
+//        articleFileService.deleteFiles(articleId, article);
+//        articleLinkService.deleteLinks(articleId, article);
 
         // 새 파일 및 링크 추가 또는 복원
-        articleFileService.processFiles(request.getFileList(), article);
+//        articleFileService.processFiles(request.getFileList(), article);
         articleLinkService.processLinks(request.getLinkList(), article);
 
         return ArticleModifyResponse.fromEntity(article);

--- a/src/main/java/com/soda/member/dto/LoginRequest.java
+++ b/src/main/java/com/soda/member/dto/LoginRequest.java
@@ -1,11 +1,16 @@
 package com.soda.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class LoginRequest {
+    @Schema(description = "사용자 ID", example = "admin01")
     private String authId;
+
+    @Schema(description = "비밀번호", example = "admin01!")
     private String password;
+
 }

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -12,6 +12,7 @@ import com.soda.request.dto.request.*;
 import com.soda.request.service.RequestService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,7 +27,7 @@ public class RequestController {
     private final LinkService linkService;
 
 
-    @PostMapping(value = "/requests")
+    @PostMapping("/requests")
     public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestBody RequestCreateRequest requestCreateRequest,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
@@ -64,7 +65,7 @@ public class RequestController {
         return ResponseEntity.ok(ApiResponseForm.success(requestDeleteResponse));
     }
 
-    @PostMapping("/requests/{requestId}/files")
+    @PostMapping(path = "/requests/{requestId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponseForm<?>> uploadFiles(@PathVariable Long requestId,
                                                           @RequestPart("file") List<MultipartFile> files,
                                                           HttpServletRequest request) {

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -12,7 +12,6 @@ import com.soda.request.dto.request.*;
 import com.soda.request.service.RequestService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,12 +26,11 @@ public class RequestController {
     private final LinkService linkService;
 
 
-    @PostMapping(value = "/requests", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestPart("data") RequestCreateRequest requestCreateRequest,
-                                                            @RequestPart(value = "file", required = false) List<MultipartFile> files,
+    @PostMapping(value = "/requests")
+    public ResponseEntity<ApiResponseForm<?>> createRequest(@RequestBody RequestCreateRequest requestCreateRequest,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest, files);
+        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(requestCreateResponse));
     }
 

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -48,12 +48,11 @@ public class RequestController {
     }
 
     @PutMapping("/requests/{requestId}")
-    public ResponseEntity<ApiResponseForm<?>> updateRequest(@RequestPart("data") RequestUpdateRequest requestUpdateRequest,
-                                                            @RequestPart(value = "file", required = false) List<MultipartFile> files,
+    public ResponseEntity<ApiResponseForm<?>> updateRequest(@RequestBody RequestUpdateRequest requestUpdateRequest,
                                                             @PathVariable Long requestId,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestUpdateResponse requestUpdateResponse = requestService.updateRequest(memberId, requestId, requestUpdateRequest, files);
+        RequestUpdateResponse requestUpdateResponse = requestService.updateRequest(memberId, requestId, requestUpdateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(requestUpdateResponse));
     }
 

--- a/src/main/java/com/soda/request/controller/ResponseController.java
+++ b/src/main/java/com/soda/request/controller/ResponseController.java
@@ -10,6 +10,7 @@ import com.soda.request.dto.response.*;
 import com.soda.request.service.ResponseService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -70,7 +71,7 @@ public class ResponseController {
         return ResponseEntity.ok(ApiResponseForm.success(responseDeleteResponse));
     }
 
-    @PostMapping("/responses/{responseId}/files")
+    @PostMapping(path = "/responses/{responseId}/files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponseForm<?>> uploadFiles(@PathVariable Long responseId,
                                                           @RequestPart("file") List<MultipartFile> files,
                                                           HttpServletRequest request) {

--- a/src/main/java/com/soda/request/controller/ResponseController.java
+++ b/src/main/java/com/soda/request/controller/ResponseController.java
@@ -59,7 +59,7 @@ public class ResponseController {
                                                             @PathVariable Long responseId,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        ResponseUpdateResponse responseUpdateResponse = responseService.updateRequest(memberId, responseId, responseUpdateRequest);
+        ResponseUpdateResponse responseUpdateResponse = responseService.updateResponse(memberId, responseId, responseUpdateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(responseUpdateResponse));
     }
 

--- a/src/main/java/com/soda/request/dto/response/RequestApproveRequest.java
+++ b/src/main/java/com/soda/request/dto/response/RequestApproveRequest.java
@@ -1,6 +1,6 @@
 package com.soda.request.dto.response;
 
-import com.soda.common.link.dto.LinkDTO;
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,5 +9,5 @@ import java.util.List;
 public class RequestApproveRequest {
     private String comment;
     private Long projectId;
-    private List<LinkDTO> links;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
 }

--- a/src/main/java/com/soda/request/dto/response/RequestRejectRequest.java
+++ b/src/main/java/com/soda/request/dto/response/RequestRejectRequest.java
@@ -1,6 +1,6 @@
 package com.soda.request.dto.response;
 
-import com.soda.common.link.dto.LinkDTO;
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Getter;
 
 import java.util.List;
@@ -9,5 +9,5 @@ import java.util.List;
 public class RequestRejectRequest {
     private String comment;
     private Long projectId;
-    private List<LinkDTO> links;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
 }

--- a/src/main/java/com/soda/request/dto/response/ResponseUpdateRequest.java
+++ b/src/main/java/com/soda/request/dto/response/ResponseUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.soda.request.dto.response;
 
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Getter;
 
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 public class ResponseUpdateRequest {
     private String comment;
     private Long projectId;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
 }

--- a/src/main/java/com/soda/request/entity/Response.java
+++ b/src/main/java/com/soda/request/entity/Response.java
@@ -41,13 +41,6 @@ public class Response extends BaseEntity {
         this.links = links;
     }
 
-    public void updateLink(List<ResponseLink> links) {
-        if (this.links == null) {
-            this.links = new ArrayList<>();
-        }
-        this.links.addAll(links);
-    }
-
     public void updateComment(String comment) {
         this.comment = comment;
     }

--- a/src/main/java/com/soda/request/entity/ResponseFile.java
+++ b/src/main/java/com/soda/request/entity/ResponseFile.java
@@ -15,10 +15,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResponseFile extends FileBase {
 
-    private String name;
-
-    private String url;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "response_id", nullable = false)
     private Response response;

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -22,7 +22,6 @@ import com.soda.request.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,14 +69,14 @@ public class RequestService {
 
 
     @Transactional
-    public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest, List<MultipartFile> files) throws GeneralException {
+    public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest) {
         Request request = getRequestOrThrow(requestId);
 
         // update요청을 한 member가 승인요청을 작성했던 member인지 확인
         validateRequestWriter(memberId, request);
 
         // request의 제목, 내용을 수정
-        updateRequestFields(requestUpdateRequest, files, request);
+        updateRequestFields(requestUpdateRequest, request);
 
         requestRepository.save(request);
         requestRepository.flush();
@@ -152,7 +151,7 @@ public class RequestService {
     }
 
     // Request(승인요청)의 제목이나 내용을 수정하는 메서드
-    private void updateRequestFields(RequestUpdateRequest requestUpdateRequest, List<MultipartFile> files, Request request) {
+    private void updateRequestFields(RequestUpdateRequest requestUpdateRequest, Request request) {
         if(requestUpdateRequest.getTitle() != null) {
             request.updateTitle(requestUpdateRequest.getTitle());
         }
@@ -161,9 +160,6 @@ public class RequestService {
         }
         if(requestUpdateRequest.getLinks() != null) {
             request.addLinks(linkService.buildLinks("request", request, requestUpdateRequest.getLinks()));
-        }
-        if(files != null) {
-            request.addFiles(fileService.buildFiles("request", request, files));
         }
     }
 

--- a/src/main/java/com/soda/request/service/ResponseService.java
+++ b/src/main/java/com/soda/request/service/ResponseService.java
@@ -1,6 +1,6 @@
 package com.soda.request.service;
 
-import com.soda.common.link.dto.LinkDTO;
+import com.soda.common.link.dto.LinkUploadRequest;
 import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.GeneralException;
 import com.soda.member.entity.Member;
@@ -105,7 +105,7 @@ public class ResponseService {
 
 
     // 분리한 메서드들
-    private Response createResponse(Member member, Request request, String comment, List<LinkDTO> linkDTOs) {
+    private Response createResponse(Member member, Request request, String comment, List<LinkUploadRequest.LinkUploadDTO> linkDTOs) {
         Response response = buildResponse(member, request, comment);
         List<ResponseLink> links = buildResponseLinks(linkDTOs);
         response.addLinks(links);
@@ -120,7 +120,7 @@ public class ResponseService {
                 .build();
     }
 
-    private List<ResponseLink> buildResponseLinks(List<LinkDTO> linkDTOs) {
+    private List<ResponseLink> buildResponseLinks(List<LinkUploadRequest.LinkUploadDTO> linkDTOs) {
         if (linkDTOs == null) return List.of();
 
         return linkDTOs.stream()

--- a/src/main/java/com/soda/request/service/ResponseService.java
+++ b/src/main/java/com/soda/request/service/ResponseService.java
@@ -1,6 +1,7 @@
 package com.soda.request.service;
 
 import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.service.LinkService;
 import com.soda.global.response.CommonErrorCode;
 import com.soda.global.response.GeneralException;
 import com.soda.member.entity.Member;
@@ -29,6 +30,7 @@ public class ResponseService {
 
     private final ResponseRepository responseRepository;
     private final MemberRepository memberRepository;
+    private final LinkService linkService;
 
 
     @Transactional
@@ -75,7 +77,7 @@ public class ResponseService {
     }
 
     @Transactional
-    public ResponseUpdateResponse updateRequest(Long memberId, Long responseId, ResponseUpdateRequest responseUpdateRequest) throws GeneralException {
+    public ResponseUpdateResponse updateResponse(Long memberId, Long responseId, ResponseUpdateRequest responseUpdateRequest) {
         Response response = getResponseOrThrow(responseId);
 
         // update요청을 한 member가 Response를 작성했던 member인지 확인
@@ -107,7 +109,7 @@ public class ResponseService {
     // 분리한 메서드들
     private Response createResponse(Member member, Request request, String comment, List<LinkUploadRequest.LinkUploadDTO> linkDTOs) {
         Response response = buildResponse(member, request, comment);
-        List<ResponseLink> links = buildResponseLinks(linkDTOs);
+        List<ResponseLink> links = linkService.buildLinks("response", response, linkDTOs);
         response.addLinks(links);
         return response;
     }
@@ -134,6 +136,9 @@ public class ResponseService {
     private void updateResponseFields(ResponseUpdateRequest responseUpdateRequest, Response response) {
         if(responseUpdateRequest.getComment() != null) {
             response.updateComment(responseUpdateRequest.getComment());
+        }
+        if(responseUpdateRequest.getLinks() != null) {
+            response.addLinks(linkService.buildLinks("response", response, responseUpdateRequest.getLinks()));
         }
     }
 

--- a/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseFileStrategy.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional(readOnly = true)
@@ -50,8 +51,18 @@ public class ResponseFileStrategy implements FileStrategy<Response, ResponseFile
     }
 
     @Override
-    public List<ResponseFile> toEntities(List<String> url, List<String> names, Response domain) {
-        return List.of();
+    public List<ResponseFile> toEntities(List<String> urls, List<String> names, Response domain) {
+        if (urls == null || urls.isEmpty()) {
+            return List.of();
+        }
+
+        return IntStream.range(0, urls.size())
+                .mapToObj(i -> ResponseFile.builder()
+                        .url(urls.get(i))
+                        .name(names.get(i))
+                        .response(domain)
+                        .build())
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
+++ b/src/main/java/com/soda/request/strategy/ResponseLinkStrategy.java
@@ -51,8 +51,18 @@ public class ResponseLinkStrategy implements LinkStrategy<Response, ResponseLink
     }
 
     @Override
-    public List<ResponseLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Response domain) {
-        return List.of();
+    public List<ResponseLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Response response) {
+        if (dtos == null || dtos.isEmpty()) {
+            return List.of();
+        }
+
+        return dtos.stream()
+                .map(dto -> ResponseLink.builder()
+                        .urlAddress(dto.getUrlAddress())
+                        .urlDescription(dto.getUrlDescription())
+                        .response(response)
+                        .build())
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- Article, Request, Response 생성/수정 API 호출 시 파일 업로드가 불가하게 하였습니다.
- 개별 파일(다중)업로드하는 API를 호출하는 방식으로 수정하였습니다.

# 연관 이슈
#74

# 확인해야할 사항
- Request, Response는 LinkService, FileService를 이용해 코드 작성하였는데,
차후 전략패턴을 폐기할 수도 있어 Article은 우선 기존 코드 주석처리하는 방식으로만 작업하였습니다.
차후 전략패턴을 폐기하고 단순화한 다음에 작업할 예정입니다.