### PR TITLE
🚧  [Refact] Article에 Link/File 전략패턴 적용 및 생성/수정시 링크 다중 삽입 가능하게 적용

### DIFF
--- a/src/main/java/com/soda/article/domain/article/ArticleCreateRequest.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleCreateRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.soda.article.entity.Article;
 import com.soda.article.enums.ArticleStatus;
 import com.soda.article.enums.PriorityType;
+import com.soda.common.link.dto.LinkUploadRequest;
 import com.soda.member.entity.Member;
 import com.soda.project.entity.Stage;
 import lombok.Builder;
@@ -25,7 +26,7 @@ public class ArticleCreateRequest {
     private Long memberId;
     private Long stageId;
     private Long parentArticleId;           // 답글인 경우 필요함
-    private List<ArticleLinkDTO> linkList;
+    private List<LinkUploadRequest.LinkUploadDTO> linkList;
 
     public Article toEntity(Member member, Stage stage, Article parentArticle) {
         return Article.builder()

--- a/src/main/java/com/soda/article/domain/article/ArticleModifyRequest.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleModifyRequest.java
@@ -2,6 +2,7 @@ package com.soda.article.domain.article;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.soda.article.enums.PriorityType;
+import com.soda.common.link.dto.LinkUploadRequest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,6 +21,6 @@ public class ArticleModifyRequest {
     private LocalDateTime deadLine;
     private Long memberId;
     private Long stageId;
-    private List<ArticleLinkDTO> linkList;
+    private List<LinkUploadRequest.LinkUploadDTO> linkList;
 
 }

--- a/src/main/java/com/soda/article/entity/Article.java
+++ b/src/main/java/com/soda/article/entity/Article.java
@@ -89,4 +89,13 @@ public class Article extends BaseEntity {
         this.deadline = deadline;
     }
 
+    public void addLinks(List<ArticleLink> links) {
+        if ( this.articleLinkList == null ) {
+            this.articleLinkList = new ArrayList<>();
+        }
+        for (ArticleLink link : links) {
+            link.updateResponse(this);
+            this.articleLinkList.add(link);
+        }
+    }
 }

--- a/src/main/java/com/soda/article/entity/ArticleFile.java
+++ b/src/main/java/com/soda/article/entity/ArticleFile.java
@@ -15,10 +15,6 @@ import lombok.NoArgsConstructor;
 @Entity
 public class ArticleFile extends FileBase {
 
-    private String name;
-
-    private String url;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id", nullable = false)
     private Article article;

--- a/src/main/java/com/soda/article/entity/ArticleLink.java
+++ b/src/main/java/com/soda/article/entity/ArticleLink.java
@@ -44,4 +44,7 @@ public class ArticleLink extends LinkBase {
         this.urlDescription = urlDescription;
     }
 
+    public void updateResponse(Article article) {
+        this.article = article;
+    }
 }

--- a/src/main/java/com/soda/article/service/ArticleLinkService.java
+++ b/src/main/java/com/soda/article/service/ArticleLinkService.java
@@ -5,6 +5,7 @@ import com.soda.article.entity.Article;
 import com.soda.article.entity.ArticleLink;
 import com.soda.article.error.ArticleErrorCode;
 import com.soda.article.repository.ArticleLinkRepository;
+import com.soda.common.link.dto.LinkUploadRequest;
 import com.soda.global.response.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -53,7 +54,7 @@ public class ArticleLinkService {
         article.getArticleLinkList().removeIf(existingLinks::contains);
     }
 
-    public void validateLinkSize(List<ArticleLinkDTO> linkList) {
+    public void validateLinkSize(List<LinkUploadRequest.LinkUploadDTO> linkList) {
         if (linkList != null && linkList.size() > MAX_SIZE) {
             throw new GeneralException(ArticleErrorCode.INVALID_INPUT);
         }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -53,7 +53,7 @@ public class ArticleService {
         Stage stage = stageService.validateStage(request.getStageId(), project);
 
         checkIfMemberIsAdmin(userRole);
-//        checkMemberInProject(member, project);
+        checkMemberInProject(member, project);
 
         Article parentArticle = null;
         if (request.getParentArticleId() != null) {
@@ -91,7 +91,7 @@ public class ArticleService {
         Project project = projectService.getValidProject(request.getProjectId());
 
         checkIfMemberIsAdmin(userRole);
-        //checkMemberInProject(member, project);
+        checkMemberInProject(member, project);
 
         Article article = validateArticle(articleId);
 

--- a/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleFileStrategy.java
@@ -2,17 +2,18 @@ package com.soda.article.strategy;
 
 import com.soda.article.entity.Article;
 import com.soda.article.entity.ArticleFile;
+import com.soda.article.error.ArticleErrorCode;
 import com.soda.article.repository.ArticleFileRepository;
 import com.soda.article.repository.ArticleRepository;
 import com.soda.common.file.strategy.FileStrategy;
 import com.soda.global.response.GeneralException;
-import com.soda.article.error.ArticleErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional
@@ -50,8 +51,18 @@ public class ArticleFileStrategy implements FileStrategy<Article, ArticleFile> {
     }
 
     @Override
-    public List<ArticleFile> toEntities(List<String> url, List<String> names, Article domain) {
-        return List.of();
+    public List<ArticleFile> toEntities(List<String> urls, List<String> names, Article domain) {
+        if (urls == null || urls.isEmpty()) {
+            return List.of();
+        }
+
+        return IntStream.range(0, urls.size())
+                .mapToObj(i -> ArticleFile.builder()
+                        .url(urls.get(i))
+                        .name(names.get(i))
+                        .article(domain)
+                        .build())
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
+++ b/src/main/java/com/soda/article/strategy/ArticleLinkStrategy.java
@@ -50,8 +50,18 @@ public class ArticleLinkStrategy implements LinkStrategy<Article, ArticleLink> {
     }
 
     @Override
-    public List<ArticleLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Article domain) {
-        return List.of();
+    public List<ArticleLink> toEntities(List<LinkUploadRequest.LinkUploadDTO> dtos, Article article) {
+        if (dtos == null || dtos.isEmpty()) {
+            return List.of();
+        }
+
+        return dtos.stream()
+                .map(dto -> ArticleLink.builder()
+                        .urlAddress(dto.getUrlAddress())
+                        .urlDescription(dto.getUrlDescription())
+                        .article(article)
+                        .build())
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
### ⚠️ 이 PR은 `refact/link-file-#76` PR이 먼저 merge된 후 머지되어야 합니다!
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- Article에 Link/File 전략패턴 적용 
- 생성/수정시 링크 다중 삽입 가능하게 적용

# 연관 이슈
#56  #74 

# 확인해야할 사항
- 전략패턴이 Request와 Response에만 적용돼있었는데 Article에도 적용함.
- 차후 전략패턴을 폐기할 수도 있지만 우선은 시스템의 일관성을 위해 Article에도 적용하였음.
- 서연님이 작성하셨던 ArticleCreate, ArticleUpdate하는 메서드에서 링크,파일부분 수정하였습니다. 살펴보시고 말씀해주세요..!!