### PR TITLE
[Feature] 몽고DB 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	// AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	// MongoDB
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/soda/SodaApplication.java
+++ b/src/main/java/com/soda/SodaApplication.java
@@ -3,9 +3,11 @@ package com.soda;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableMongoRepositories
 public class SodaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/soda/global/log/LogController.java
+++ b/src/main/java/com/soda/global/log/LogController.java
@@ -1,0 +1,21 @@
+package com.soda.global.log;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LogController {
+    private final LogService logService;
+
+    @GetMapping("/test")
+    public ResponseEntity log() {
+        String test = "hi";
+        LogInfo logInfo = logService.findLogInfoByTest(test);
+
+        return new ResponseEntity(logInfo, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/soda/global/log/LogInfo.java
+++ b/src/main/java/com/soda/global/log/LogInfo.java
@@ -1,0 +1,17 @@
+package com.soda.global.log;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "data_log") // 실제 몽고 DB 컬렉션 이름
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogInfo {
+    @Id
+    private String id;
+    private String test;
+}

--- a/src/main/java/com/soda/global/log/LogRepository.java
+++ b/src/main/java/com/soda/global/log/LogRepository.java
@@ -1,0 +1,9 @@
+package com.soda.global.log;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LogRepository extends MongoRepository<LogInfo, String> {
+    LogInfo findLogInfoByTest(String test);
+}

--- a/src/main/java/com/soda/global/log/LogService.java
+++ b/src/main/java/com/soda/global/log/LogService.java
@@ -1,0 +1,14 @@
+package com.soda.global.log;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+    private final LogRepository logRepository;
+
+    public LogInfo findLogInfoByTest(String test) {
+        return logRepository.findLogInfoByTest(test);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,10 @@ spring:
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  data:
+    mongodb:
+      uri: mongodb+srv://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_HOST}/${MONGODB_DB}?retryWrites=true&w=majority&appName=${MONGODB_APP_NAME}
+
 logging:
   level:
     com.practice.simple: debug


### PR DESCRIPTION

# 요약
- 몽고 DB 연결 및 몽고DB의 데이터가 잘 조회되는지 테스트하는 API 구현하였습니다.


# 연관 이슈
#78 

# 몽고DB 연결 이유
- 데이터 생성/수정/삭제 로그를 쌓아야하는데 엔티티마다 필드가 달라 RDB보다는 NoSQL이 적합함.
- 몽고DB와 Elasticsearch를 고민하였지만, 현재 시스템의 크기로서는 몽고DB가 적합하다고 생각하였음. 차후 시스템이 확장되고 로그량이 많아지면 Elasticsearch로 이관하는 방안도 고려해볼 수 있을 것 같음.

# 확인해야할 사항
- 몽고DB Atlas라는 클라우드 db를 사용함.
  - AWS RDS로 MySQL을 사용하는 것과 유사함.
  - 엔드포인트 따로 전달드리겠습니다.
- .env파일이 업데이트되어 따로 전달드리겠습니다