### PR TITLE
[fix] 조회 시 id 없는 버그 해결

### DIFF
--- a/src/main/java/com/soda/project/domain/ProjectListResponse.java
+++ b/src/main/java/com/soda/project/domain/ProjectListResponse.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ProjectListResponse {
 
+    private Long id;
     private String title;
     private String description;
     private LocalDateTime startDate;

--- a/src/main/java/com/soda/project/domain/ProjectResponse.java
+++ b/src/main/java/com/soda/project/domain/ProjectResponse.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Builder
 public class ProjectResponse {
 
+    private Long id;
     private String title;
     private String description;
     private LocalDateTime startDate;

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -129,6 +129,7 @@ public class  ProjectService {
         String clientCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.CLIENT_COMPANY);
 
         return ProjectListResponse.builder()
+                .id(project.getId())
                 .title(project.getTitle())
                 .description(project.getDescription())
                 .startDate(project.getStartDate())
@@ -154,6 +155,7 @@ public class  ProjectService {
         List<Member> clientParticipants = memberProjectService.getMembersByRole(project, MemberProjectRole.CLI_PARTICIPANT);
 
         return ProjectResponse.builder()
+                .id(project.getId())
                 .title(project.getTitle())
                 .description(project.getDescription())
                 .startDate(project.getStartDate())


### PR DESCRIPTION

# 요약
프론트와 연동 시 response에 id가 존재하지 않아 연동이 되지 않는 오류를 해결하기 위해 response를 수정했습니다.

# 연관 이슈
closes #85 


# 확인 사항
- response에 id를 추가하였습니다.