### PR TITLE
[fix]: StageReadResponse 조회시 task정보 추가

### DIFF
--- a/src/main/java/com/soda/project/domain/stage/StageReadResponse.java
+++ b/src/main/java/com/soda/project/domain/stage/StageReadResponse.java
@@ -1,21 +1,29 @@
 package com.soda.project.domain.stage;
 
+import com.soda.project.domain.task.TaskReadResponse;
 import com.soda.project.entity.Stage;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class StageReadResponse {
     private Long id;
     private String name;
     private Float stageOrder;
+    private List<TaskReadResponse> tasks;
 
-    private StageReadResponse() {} // 직접 생성 방지
+    private StageReadResponse() {}
 
     public static StageReadResponse fromEntity(Stage stage) {
         StageReadResponse dto = new StageReadResponse();
         dto.id = stage.getId();
         dto.name = stage.getName();
         dto.stageOrder = stage.getStageOrder();
+        dto.tasks = stage.getTaskList().stream()
+                .map(TaskReadResponse::fromEntity)
+                .collect(Collectors.toList());
         return dto;
     }
 }


### PR DESCRIPTION

# 요약
프론트와 연동 시 StageReadResponse에 task 정보를 추가했습니다.


# 연관 이슈
#87

# Pull Request 체크리스트


## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
