### PR TITLE
[Fix] Article, Comment API 연동 시 오류 해결

### DIFF
--- a/src/main/java/com/soda/article/domain/article/ArticleCreateResponse.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleCreateResponse.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ArticleCreateResponse {
 
+    private Long id;
     private String title;
     private String content;
     private PriorityType priority;
@@ -27,6 +28,7 @@ public class ArticleCreateResponse {
 
     public static ArticleCreateResponse fromEntity(Article article) {
         return ArticleCreateResponse.builder()
+                .id(article.getId())
                 .title(article.getTitle())
                 .content(article.getContent())
                 .priority(article.getPriority())

--- a/src/main/java/com/soda/article/domain/article/ArticleViewResponse.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleViewResponse.java
@@ -22,6 +22,7 @@ public class ArticleViewResponse {
     private String stageName;
     private List<ArticleFileDTO> fileList;
     private List<ArticleLinkDTO> linkList;
+    private LocalDateTime createdAt;
 
     public static ArticleViewResponse fromEntity(Article article) {
         return ArticleViewResponse.builder()
@@ -31,6 +32,7 @@ public class ArticleViewResponse {
                 .deadLine(article.getDeadline())
                 .memberName(article.getMember().getName())
                 .stageName(article.getStage().getName())
+                .createdAt(article.getCreatedAt())
                 .fileList(article.getArticleFileList().stream()
                         .map(file -> ArticleFileDTO.builder()
                                 .name(file.getName())

--- a/src/main/java/com/soda/article/domain/comment/CommentDTO.java
+++ b/src/main/java/com/soda/article/domain/comment/CommentDTO.java
@@ -20,6 +20,7 @@ public class CommentDTO {
     private Long parentCommentId; // 부모 댓글 ID (대댓글의 경우)
     private List<CommentDTO> childComments; // 자식 댓글 리스트
     private LocalDateTime createdAt;
+    private boolean deleted;
 
     // 엔티티를 DTO로 변환하는 메소드
     public static CommentDTO fromEntity(Comment comment) {
@@ -41,6 +42,7 @@ public class CommentDTO {
                 .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .childComments(childCommentDTOs) // 자식 댓글을 포함
                 .createdAt(comment.getCreatedAt())
+                .deleted(comment.getIsDeleted())
                 .build();
     }
 
@@ -53,6 +55,8 @@ public class CommentDTO {
                 .articleId(this.articleId)
                 .parentCommentId(this.parentCommentId)
                 .childComments(childComments)
+                .createdAt(this.createdAt)
+                .deleted(this.isDeleted())
                 .build();
     }
 

--- a/src/main/java/com/soda/article/domain/comment/CommentDTO.java
+++ b/src/main/java/com/soda/article/domain/comment/CommentDTO.java
@@ -5,6 +5,7 @@ import com.soda.article.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,6 +19,7 @@ public class CommentDTO {
     private Long articleId; // 게시글 ID
     private Long parentCommentId; // 부모 댓글 ID (대댓글의 경우)
     private List<CommentDTO> childComments; // 자식 댓글 리스트
+    private LocalDateTime createdAt;
 
     // 엔티티를 DTO로 변환하는 메소드
     public static CommentDTO fromEntity(Comment comment) {
@@ -38,6 +40,7 @@ public class CommentDTO {
                 .articleId(comment.getArticle().getId())
                 .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .childComments(childCommentDTOs) // 자식 댓글을 포함
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/soda/article/repository/CommentRepository.java
+++ b/src/main/java/com/soda/article/repository/CommentRepository.java
@@ -15,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleAndIsDeletedFalse(Article article);
 
     Optional<Comment> findByIdAndIsDeletedFalse(Long commentId);
+
+    List<Comment> findAllByArticle(Article article);
 }

--- a/src/main/java/com/soda/article/service/CommentService.java
+++ b/src/main/java/com/soda/article/service/CommentService.java
@@ -105,7 +105,7 @@ public class CommentService {
         checkIfMemberIsAdminOrProjectMember(userRole, member, project);
 
         // 2. 댓글 조회
-        List<Comment> comments = commentRepository.findByArticleAndIsDeletedFalse(article);
+        List<Comment> comments = commentRepository.findAllByArticle(article);
 
         List<CommentDTO> commentDTOList = comments.stream()
                 .map(CommentDTO::fromEntity) // Comment 엔티티를 DTO로 변환
@@ -126,7 +126,6 @@ public class CommentService {
                 .filter(commentDTO -> commentDTO.getParentCommentId() == null) // 부모 댓글만 반환
                 .collect(Collectors.toList());
     }
-
 
     /**
      * 자식 댓글을 부모 댓글에 추가하는 재귀 메소드


### PR DESCRIPTION

# 요약
프론트와 연동 시 발생한 오류를 해결했습니다.

# 연관 이슈
closed #90 

# 확인할 사항
### 1. article, comment response에 createdAt 추가
- createdAt이 없어서 최신순 조회가 안되고 있어서 추가했습니다.
### 2.유효성 검사 오류 해결
- 관리자/해당 프로젝트 참여자만 조회 가능한 경우로 로직 수정했습니다.
### 댓글 전체 조회 오류 해결
- 댓글 조회 시, 삭제된 부모 댓글이 존재하는 경우 자식 댓글들이 조회가 되지 않는 오류가 발생했습니다.
- 그래서 전체 조회되도록 repository 코드를 수정하고, response에 delete를 추가했습니다.
- 프론트에서는 delete treu인 댓글은 제외되도록 예외처리하고 연동하였습니다.