### PR TITLE
[Fix] 게시글 전체 조회 오류 수정

### DIFF
--- a/src/main/java/com/soda/article/domain/article/ArticleListViewResponse.java
+++ b/src/main/java/com/soda/article/domain/article/ArticleListViewResponse.java
@@ -24,6 +24,7 @@ public class ArticleListViewResponse {
     private LocalDateTime createdAt;
     private Long parentArticleId;
     private List<ArticleListViewResponse> children;     // 자식 게시글 리스트
+    private boolean isDeleted;
 
     public static ArticleListViewResponse fromEntity(Article article) {
         List<ArticleListViewResponse> childArticleDTOs = article.getChildArticles() != null ?
@@ -42,6 +43,7 @@ public class ArticleListViewResponse {
                 .createdAt(article.getCreatedAt())
                 .parentArticleId(article.getParentArticle() != null ? article.getParentArticle().getId() : null)
                 .children(childArticleDTOs)
+                .isDeleted(article.getIsDeleted())
                 .build();
     }
 
@@ -56,6 +58,7 @@ public class ArticleListViewResponse {
                 .deadLine(this.getDeadLine())
                 .createdAt(this.getCreatedAt())
                 .children(childArticles)
+                .isDeleted(this.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/soda/article/repository/ArticleRepository.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepository.java
@@ -18,4 +18,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     List<Article> findByIsDeletedFalseAndStageAndStage_Project(Stage stage, Project project);
 
+    List<Article> findByStage_Project(Project project);
+
+    List<Article> findByStageAndStage_Project(Stage stage, Project project);
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -237,9 +237,9 @@ public class ArticleService {
     private List<Article> getArticlesByStageAndProject(Long stageId, Project project) {
         if (stageId != null) {
             Stage stage = stageService.findById(stageId);
-            return articleRepository.findByIsDeletedFalseAndStageAndStage_Project(stage, project);
+            return articleRepository.findByStageAndStage_Project(stage, project);
         }
-        return articleRepository.findByIsDeletedFalseAndStage_Project(project);
+        return articleRepository.findByStage_Project(project);
     }
 
     /**


### PR DESCRIPTION

# 요약
게시글 전체 조회 시 삭제된 게시글 조회 되지 않도록 수정하였습니다.


# 연관 이슈
closes #105 

# 확인사항
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/13d8871b-0dd7-4f73-b24e-f05e1705d0a8" />
- 부모 게시글이 삭제되었어도 자식 게시글을 조회하기 위하여 로직을 수정했습니다.
- response에 `boolean isDeleted`를 추가하여 삭제 여부를 판단할 수 있도록 하였습니다.
- `isDeletedFalse` 삭제하고 전체 게시글을 조회한 다음 프론트 단에서 삭제된 게시글을 조회할 수 없도록 수정하였습니다.