### PR TITLE
[Feature] 첫 로그인 사용자 정보 업데이트 API 개발 및 사용자 관련 오류 수정

### DIFF
--- a/src/main/java/com/soda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/soda/global/config/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 //@OpenAPIDefinition(
@@ -17,7 +20,11 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
+        Server productionServer = new Server();
+        productionServer.setUrl("https://api.s0da.co.kr");
+        productionServer.setDescription("Production Server");
         return new OpenAPI()
+                .servers(List.of(productionServer))
                 .components(new Components()
                         .addSecuritySchemes("accessToken", new SecurityScheme()
                                 .name("Authorization") // 헤더 이름

--- a/src/main/java/com/soda/member/controller/MemberController.java
+++ b/src/main/java/com/soda/member/controller/MemberController.java
@@ -3,16 +3,15 @@ package com.soda.member.controller;
 import com.soda.global.response.ApiResponseForm;
 import com.soda.member.dto.FindAuthIdRequest;
 import com.soda.member.dto.FindAuthIdResponse;
+import com.soda.member.dto.InitialUserInfoRequestDto;
+import com.soda.member.dto.member.admin.MemberDetailDto;
 import com.soda.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping
+@RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
@@ -20,15 +19,24 @@ public class MemberController {
 
     /**
      * 이름과 이메일을 받아 마스킹된 아이디를 반환합니다.
+     *
      * @param request 이름과 이메일 정보
      * @return 성공 시 200 OK와 마스킹된 아이디, 실패 시 404 Not Found
      */
-    @PostMapping("/members/find-id")
+    @PostMapping("/find-id")
     public ResponseEntity<ApiResponseForm<FindAuthIdResponse>> findAuthId(
             @Valid @RequestBody FindAuthIdRequest request) {
 
         FindAuthIdResponse responseDto = memberService.findMaskedAuthId(request);
 
         return ResponseEntity.ok(ApiResponseForm.success(responseDto, "아이디 찾기 성공"));
+    }
+
+    @PutMapping("/{memberId}/initial-profile")
+    public ResponseEntity<ApiResponseForm<MemberDetailDto>> setupInitialProfile(
+            @PathVariable Long memberId,
+            @Valid @RequestBody InitialUserInfoRequestDto requestDto) {
+        memberService.setupInitialProfile(memberId, requestDto);
+        return ResponseEntity.ok(ApiResponseForm.success(null, "초기 사용자 정보가 성공적으로 등록되었습니다."));
     }
 }

--- a/src/main/java/com/soda/member/dto/InitialUserInfoRequestDto.java
+++ b/src/main/java/com/soda/member/dto/InitialUserInfoRequestDto.java
@@ -1,0 +1,25 @@
+package com.soda.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class InitialUserInfoRequestDto {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    private String phoneNumber;
+
+    private String authId;
+
+    private String password;
+
+    private String position;
+
+}

--- a/src/main/java/com/soda/member/dto/member/LoginResponse.java
+++ b/src/main/java/com/soda/member/dto/member/LoginResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LoginResponse {
+    private Long memberId;
     private String name;
     private String authId;
     private String email;
@@ -24,6 +25,7 @@ public class LoginResponse {
         boolean firstLogin = (member.getEmail() == null);
         MemberRole memberRole = member.getRole();
         return LoginResponse.builder()
+                .memberId(member.getId())
                 .name(member.getName())
                 .authId(member.getAuthId())
                 .email(member.getEmail())

--- a/src/main/java/com/soda/member/entity/Member.java
+++ b/src/main/java/com/soda/member/entity/Member.java
@@ -61,6 +61,15 @@ public class Member extends BaseEntity {
         this.phoneNumber = phoneNumber;
     }
 
+    public void initialProfile(String name, String email, String phoneNumber, String authId, String newPassword, String position) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.authId = authId;
+        this.password = newPassword;
+        this.position = position;
+    }
+
     public void Deleted() {
         this.markAsDeleted();
     }

--- a/src/main/java/com/soda/member/service/AuthService.java
+++ b/src/main/java/com/soda/member/service/AuthService.java
@@ -9,6 +9,7 @@ import com.soda.member.dto.member.LoginResponse;
 import com.soda.member.dto.member.admin.CreateMemberRequest;
 import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberRole;
 import com.soda.member.error.AuthErrorCode;
 import com.soda.member.repository.RefreshTokenRepository;
 import com.soda.member.repository.VerificationCodeRepository;
@@ -67,7 +68,7 @@ public class AuthService {
         log.info("회원 가입 시도: authId={}", requestDto.getAuthId());
         memberService.validateDuplicateAuthId(requestDto.getAuthId());
         Company company = null;
-        if(requestDto.getCompanyId()!=null){
+        if(requestDto.getRole().equals(MemberRole.USER)){
             company = companyService.getCompany(requestDto.getCompanyId());
         }
 

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -240,7 +240,7 @@ public class MemberService {
 
         Member member = findByIdAndIsDeletedFalse(memberId);
 
-        member.updateInfo(requestDto.getName(),
+        member.initialProfile(requestDto.getName(),
                 requestDto.getEmail(),
                 requestDto.getPhoneNumber(),
                 requestDto.getAuthId(),

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.soda.member.service;
 import com.soda.global.response.GeneralException;
 import com.soda.member.dto.FindAuthIdRequest;
 import com.soda.member.dto.FindAuthIdResponse;
+import com.soda.member.dto.InitialUserInfoRequestDto;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.MemberRole;
 import com.soda.member.error.MemberErrorCode;
@@ -233,5 +234,20 @@ public class MemberService {
      */
     public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
         return memberRepository.findByKeywordIncludingDeleted(keyword, pageable);
+    }
+
+    public void setupInitialProfile(Long memberId, InitialUserInfoRequestDto requestDto) {
+
+        Member member = findByIdAndIsDeletedFalse(memberId);
+
+        member.updateInfo(requestDto.getName(),
+                requestDto.getEmail(),
+                requestDto.getPhoneNumber(),
+                requestDto.getAuthId(),
+                passwordEncoder.encode(requestDto.getPassword()),
+                requestDto.getPosition()
+                );
+
+        memberRepository.save(member);
     }
 }


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
사용자가 최초 로그인 후 필수 프로필 정보(이름, 이메일, 전화번호, 아이디, 비밀번호, 직책 등)를 설정하는 기능을 구현했습니다. 
이와 함께 로그인 응답에 사용자 ID를 추가하고, 관리자 사용자 생성 관련 오류 및 Swagger 설정을 수정했습니다.

## 주요 변경 사항

1.  **사용자 초기 프로필 설정 기능 추가:**
    *   사용자가 필수 정보를 입력하여 초기 프로필을 설정하는 API 를 구현했습니다 
    *   초기 설정 요청을 처리하기 위한 DTO (`InitialUserInfoRequestDto`)를 생성했습니다.
    *   프로필 정보를 업데이트하는 서비스 로직 (`MemberService.setupInitialProfile`)을 구현했습니다.
    *   `Member` 엔티티에 초기 프로필 정보를 한 번에 업데이트하는 `initialProfile` 메소드를 추가했습니다.

2.  **로그인 응답 수정:**
    *   로그인 성공 시 반환되는 `LoginResponse` DTO에 `memberId` 필드를 추가하여, 클라이언트에서 사용자 식별이 용이하도록 개선했습니다.

3.  **관리자 사용자 생성 로직 수정:**
    *   관리자(ADMIN) 역할의 사용자를 생성할 때, 회사 ID(`companyId`)가 제공되더라도 실제로는 회사 정보를 연결하지 않도록 `AuthService.signup` 로직을 수정하여 관련 오류를 해결했습니다.

4.  **Swagger 설정 수정:**
    *   `SwaggerConfig`에서 API 서버 주소(`servers` 설정)를 명시적으로 설정하여 배포 환경에서의 Swagger UI 동작을 개선했습니다.

# 연관 이슈
#123

# Pull Request 체크리스트

## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
