### PR TITLE
[feature] 프로젝트 조회 응답에 현재 사용자 역할 추가 

### DIFF
--- a/src/main/java/com/soda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/soda/global/config/SwaggerConfig.java
@@ -1,30 +1,26 @@
 package com.soda.global.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
-
 @Configuration
-//@OpenAPIDefinition(
-//        servers = {
-//                @Server(url = "ec2-54-180-108-126.ap-northeast-2.compute.amazonaws.com", description = "Production Server")
-//        }
-//)
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "https://api.s0da.co.kr", description = "Production Server"),
+                @Server(url = "http://localhost:8080", description = "Local Development Server")
+        }
+)
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
-        Server productionServer = new Server();
-        productionServer.setUrl("https://api.s0da.co.kr");
-        productionServer.setDescription("Production Server");
         return new OpenAPI()
-                .servers(List.of(productionServer))
                 .components(new Components()
                         .addSecuritySchemes("accessToken", new SecurityScheme()
                                 .name("Authorization") // 헤더 이름

--- a/src/main/java/com/soda/global/config/SwaggerConfig.java
+++ b/src/main/java/com/soda/global/config/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 //@OpenAPIDefinition(
@@ -17,7 +20,11 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
+        Server productionServer = new Server();
+        productionServer.setUrl("https://api.s0da.co.kr");
+        productionServer.setDescription("Production Server");
         return new OpenAPI()
+                .servers(List.of(productionServer))
                 .components(new Components()
                         .addSecuritySchemes("accessToken", new SecurityScheme()
                                 .name("Authorization") // 헤더 이름

--- a/src/main/java/com/soda/member/controller/MemberController.java
+++ b/src/main/java/com/soda/member/controller/MemberController.java
@@ -3,16 +3,15 @@ package com.soda.member.controller;
 import com.soda.global.response.ApiResponseForm;
 import com.soda.member.dto.FindAuthIdRequest;
 import com.soda.member.dto.FindAuthIdResponse;
+import com.soda.member.dto.InitialUserInfoRequestDto;
+import com.soda.member.dto.member.admin.MemberDetailDto;
 import com.soda.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping
+@RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
@@ -20,15 +19,24 @@ public class MemberController {
 
     /**
      * 이름과 이메일을 받아 마스킹된 아이디를 반환합니다.
+     *
      * @param request 이름과 이메일 정보
      * @return 성공 시 200 OK와 마스킹된 아이디, 실패 시 404 Not Found
      */
-    @PostMapping("/members/find-id")
+    @PostMapping("/find-id")
     public ResponseEntity<ApiResponseForm<FindAuthIdResponse>> findAuthId(
             @Valid @RequestBody FindAuthIdRequest request) {
 
         FindAuthIdResponse responseDto = memberService.findMaskedAuthId(request);
 
         return ResponseEntity.ok(ApiResponseForm.success(responseDto, "아이디 찾기 성공"));
+    }
+
+    @PutMapping("/{memberId}/initial-profile")
+    public ResponseEntity<ApiResponseForm<MemberDetailDto>> setupInitialProfile(
+            @PathVariable Long memberId,
+            @Valid @RequestBody InitialUserInfoRequestDto requestDto) {
+        memberService.setupInitialProfile(memberId, requestDto);
+        return ResponseEntity.ok(ApiResponseForm.success(null, "초기 사용자 정보가 성공적으로 등록되었습니다."));
     }
 }

--- a/src/main/java/com/soda/member/dto/InitialUserInfoRequestDto.java
+++ b/src/main/java/com/soda/member/dto/InitialUserInfoRequestDto.java
@@ -1,0 +1,25 @@
+package com.soda.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class InitialUserInfoRequestDto {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    private String phoneNumber;
+
+    private String authId;
+
+    private String password;
+
+    private String position;
+
+}

--- a/src/main/java/com/soda/member/dto/member/LoginResponse.java
+++ b/src/main/java/com/soda/member/dto/member/LoginResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class LoginResponse {
+    private Long memberId;
     private String name;
     private String authId;
     private String email;
@@ -24,6 +25,7 @@ public class LoginResponse {
         boolean firstLogin = (member.getEmail() == null);
         MemberRole memberRole = member.getRole();
         return LoginResponse.builder()
+                .memberId(member.getId())
                 .name(member.getName())
                 .authId(member.getAuthId())
                 .email(member.getEmail())

--- a/src/main/java/com/soda/member/entity/Member.java
+++ b/src/main/java/com/soda/member/entity/Member.java
@@ -61,6 +61,15 @@ public class Member extends BaseEntity {
         this.phoneNumber = phoneNumber;
     }
 
+    public void initialProfile(String name, String email, String phoneNumber, String authId, String newPassword, String position) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.authId = authId;
+        this.password = newPassword;
+        this.position = position;
+    }
+
     public void Deleted() {
         this.markAsDeleted();
     }

--- a/src/main/java/com/soda/member/service/AuthService.java
+++ b/src/main/java/com/soda/member/service/AuthService.java
@@ -9,6 +9,7 @@ import com.soda.member.dto.member.LoginResponse;
 import com.soda.member.dto.member.admin.CreateMemberRequest;
 import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberRole;
 import com.soda.member.error.AuthErrorCode;
 import com.soda.member.repository.RefreshTokenRepository;
 import com.soda.member.repository.VerificationCodeRepository;
@@ -67,7 +68,7 @@ public class AuthService {
         log.info("회원 가입 시도: authId={}", requestDto.getAuthId());
         memberService.validateDuplicateAuthId(requestDto.getAuthId());
         Company company = null;
-        if(requestDto.getCompanyId()!=null){
+        if(requestDto.getRole().equals(MemberRole.USER)){
             company = companyService.getCompany(requestDto.getCompanyId());
         }
 

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -240,7 +240,7 @@ public class MemberService {
 
         Member member = findByIdAndIsDeletedFalse(memberId);
 
-        member.updateInfo(requestDto.getName(),
+        member.initialProfile(requestDto.getName(),
                 requestDto.getEmail(),
                 requestDto.getPhoneNumber(),
                 requestDto.getAuthId(),

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.soda.member.service;
 import com.soda.global.response.GeneralException;
 import com.soda.member.dto.FindAuthIdRequest;
 import com.soda.member.dto.FindAuthIdResponse;
+import com.soda.member.dto.InitialUserInfoRequestDto;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.MemberRole;
 import com.soda.member.error.MemberErrorCode;
@@ -233,5 +234,20 @@ public class MemberService {
      */
     public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
         return memberRepository.findByKeywordIncludingDeleted(keyword, pageable);
+    }
+
+    public void setupInitialProfile(Long memberId, InitialUserInfoRequestDto requestDto) {
+
+        Member member = findByIdAndIsDeletedFalse(memberId);
+
+        member.updateInfo(requestDto.getName(),
+                requestDto.getEmail(),
+                requestDto.getPhoneNumber(),
+                requestDto.getAuthId(),
+                passwordEncoder.encode(requestDto.getPassword()),
+                requestDto.getPosition()
+                );
+
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -39,8 +39,10 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
-    public ResponseEntity<ApiResponseForm<ProjectResponse>> getProject(@PathVariable Long projectId) {
-        ProjectResponse response = projectService.getProject(projectId);
+    public ResponseEntity<ApiResponseForm<ProjectResponse>> getProject(HttpServletRequest request, @PathVariable Long projectId) {
+        Long userId = (Long) request.getAttribute("memberId");
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectResponse response = projectService.getProject(projectId, userId, userRole);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 
@@ -55,7 +57,6 @@ public class ProjectController {
         ProjectCreateResponse response = projectService.updateProject(projectId, request);
         return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트 수정 성공"));
     }
-
 
 
     @PatchMapping("/{projectId}/status")

--- a/src/main/java/com/soda/project/domain/ProjectResponse.java
+++ b/src/main/java/com/soda/project/domain/ProjectResponse.java
@@ -24,8 +24,8 @@ public class ProjectResponse {
     private LocalDateTime endDate;
     private ProjectStatus status;
 
-    private MemberProjectRole currentUserProjectRole;
-    private CompanyProjectRole currentUserCompanyRole;
+    private String currentUserProjectRole;
+    private String currentUserCompanyRole;
 
     // 고객사 정보
     private String clientCompanyName;      // 고객사 이름

--- a/src/main/java/com/soda/project/domain/ProjectResponse.java
+++ b/src/main/java/com/soda/project/domain/ProjectResponse.java
@@ -1,5 +1,7 @@
 package com.soda.project.domain;
 
+import com.soda.member.enums.CompanyProjectRole;
+import com.soda.member.enums.MemberProjectRole;
 import com.soda.project.enums.ProjectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,9 @@ public class ProjectResponse {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private ProjectStatus status;
+
+    private MemberProjectRole currentUserProjectRole;
+    private CompanyProjectRole currentUserCompanyRole;
 
     // 고객사 정보
     private String clientCompanyName;      // 고객사 이름

--- a/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
@@ -17,4 +17,6 @@ public interface CompanyProjectRepository extends JpaRepository<CompanyProject, 
     Optional<CompanyProject> findByProjectAndCompanyProjectRole(Project project, CompanyProjectRole companyProjectRole);
 
     List<CompanyProject> findByProject(Project project);
+
+    Optional<CompanyProject> findByCompanyAndProjectAndIsDeletedFalse(Company company, Project project);
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -30,4 +30,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     Optional<MemberProject> findByMemberAndProject(Member member, Project project);
 
     List<MemberProject> findByMemberId(Long userId);
+
+    Optional<MemberProject> findByMemberAndProjectAndIsDeletedFalse(Member member, Project project);
 }

--- a/src/main/java/com/soda/project/service/CompanyProjectService.java
+++ b/src/main/java/com/soda/project/service/CompanyProjectService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Transactional(readOnly = true)
 @Service
@@ -64,5 +65,16 @@ public class CompanyProjectService {
     private CompanyProject findByProjectAndCompanyProjectRole(Project project, CompanyProjectRole role) {
         return companyProjectRepository.findByProjectAndCompanyProjectRole(project, role)
                 .orElseThrow(() -> new GeneralException(ProjectErrorCode.COMPANY_NOT_FOUND));
+    }
+
+    /**
+     * 특정 회사와 프로젝트의 관계에 대한 CompanyProjectRole을 반환합니다.
+     * @param company 회사 엔티티
+     * @param project 프로젝트 엔티티
+     * @return CompanyProjectRole (CLIENT 또는 DEVELOPER). 관계가 없으면 null을 반환합니다.
+     */
+    public CompanyProjectRole getCompanyRoleInProject(Company company, Project project) {
+        Optional<CompanyProject> companyProjectOpt = companyProjectRepository.findByCompanyAndProjectAndIsDeletedFalse(company, project);
+        return companyProjectOpt.map(CompanyProject::getCompanyProjectRole).orElse(null);
     }
 }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -90,5 +91,18 @@ public class MemberProjectService {
         return memberProjects.stream()
                 .map(memberProject -> memberProject.getProject().getId())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 프로젝트에서 특정 멤버의 역할을 조회합니다.
+     * 멤버가 해당 프로젝트에 참여하지 않거나, 참여 정보가 삭제된 경우 null을 반환합니다.
+     *
+     * @param project 조회할 프로젝트 엔티티
+     * @param member  역할을 조회할 멤버 엔티티
+     * @return 해당 프로젝트에서의 MemberProjectRole, 참여하지 않거나 삭제된 경우 null
+     */
+    public MemberProjectRole getMemberRoleInProject(Member member, Project project) {
+        Optional<MemberProject> memberProjectOpt = memberProjectRepository.findByMemberAndProjectAndIsDeletedFalse(member, project);
+        return memberProjectOpt.map(MemberProject::getRole).orElse(null);
     }
 }

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -159,14 +159,24 @@ public class ProjectService {
     }
 
     // 개별 프로젝트 조회
-    public ProjectResponse getProject(Long projectId) {
+    public ProjectResponse getProject(Long projectId, Long userId, String userRole) {
         Project project = getValidProject(projectId);
-        return mapToProjectResponse(project);
+        Member member = memberService.findMemberById(userId);
+
+        return mapToProjectResponse(project, member, userRole);
     }
 
-    private ProjectResponse mapToProjectResponse(Project project) {
+    private ProjectResponse mapToProjectResponse(Project project, Member member, String userRole) {
         String devCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.DEV_COMPANY);
         String clientCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.CLIENT_COMPANY);
+
+        MemberProjectRole currentMemberProjectRole = null;
+        CompanyProjectRole currentcompanyProjectRole = null;
+        if (userRole.equals("USER")) {
+            currentMemberProjectRole = memberProjectService.getMemberRoleInProject(member, project);
+            currentcompanyProjectRole = companyProjectService.getCompanyRoleInProject(member.getCompany(), project);
+        }
+
 
         List<Member> devManagers = memberProjectService.getMembersByRole(project, MemberProjectRole.DEV_MANAGER);
         List<Member> devParticipants = memberProjectService.getMembersByRole(project, MemberProjectRole.DEV_PARTICIPANT);
@@ -180,6 +190,8 @@ public class ProjectService {
                 .startDate(project.getStartDate())
                 .endDate(project.getEndDate())
                 .status(project.getStatus())
+                .currentUserProjectRole(currentMemberProjectRole)
+                .currentUserCompanyRole(currentcompanyProjectRole)
                 .devCompanyName(devCompanyName)
                 .devCompanyManagers(extractMemberNames(devManagers))
                 .devCompanyMembers(extractMemberNames(devParticipants))

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -34,6 +34,8 @@ public class ProjectService {
     private final CompanyService companyService;
     private final StageService stageService;
 
+    private static final String ADMIN_ROLE = "ADMIN";
+
     /*
         프로젝트 생성하기
         - 기본 정보 생성
@@ -170,11 +172,15 @@ public class ProjectService {
         String devCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.DEV_COMPANY);
         String clientCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.CLIENT_COMPANY);
 
-        String currentMemberProjectRole = "ADMIN";
-        String currentcompanyProjectRole = "ADMIN";
+        String currentMemberProjectRole = null;
+        String currentcompanyProjectRole = null;
         if (userRole.equals("USER")) {
             currentMemberProjectRole = memberProjectService.getMemberRoleInProject(member, project).getDescription();
             currentcompanyProjectRole = companyProjectService.getCompanyRoleInProject(member.getCompany(), project).getDescription();
+        }
+        if (userRole.equals(ADMIN_ROLE)) {
+            currentMemberProjectRole = ADMIN_ROLE;
+            currentcompanyProjectRole = ADMIN_ROLE;
         }
 
 

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -170,11 +170,11 @@ public class ProjectService {
         String devCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.DEV_COMPANY);
         String clientCompanyName = companyProjectService.getCompanyNameByRole(project, CompanyProjectRole.CLIENT_COMPANY);
 
-        MemberProjectRole currentMemberProjectRole = null;
-        CompanyProjectRole currentcompanyProjectRole = null;
+        String currentMemberProjectRole = "ADMIN";
+        String currentcompanyProjectRole = "ADMIN";
         if (userRole.equals("USER")) {
-            currentMemberProjectRole = memberProjectService.getMemberRoleInProject(member, project);
-            currentcompanyProjectRole = companyProjectService.getCompanyRoleInProject(member.getCompany(), project);
+            currentMemberProjectRole = memberProjectService.getMemberRoleInProject(member, project).getDescription();
+            currentcompanyProjectRole = companyProjectService.getCompanyRoleInProject(member.getCompany(), project).getDescription();
         }
 
 


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
개별 프로젝트 조회 API 응답에 **현재 API를 호출한 사용자**의 역할 정보를 추가했습니다. 
이를 통해 클라이언트는 사용자의 프로젝트 내 역할 및 소속 회사의 역할(고객사/개발사)을 바로 확인할 수 있습니다.

## 주요 변경 사항

1.  **프로젝트 응답 DTO 수정 (`ProjectResponse`):**
    *   `currentUserProjectRole` 필드 추가: 조회 중인 사용자의 해당 프로젝트 내 역할 
    *   `currentUserCompanyRole`필드 추가: 조회 중인 사용자가 속한 회사의 해당 프로젝트 내 역할 
2.  **역할 조회 서비스 로직 추가:**
    *   `MemberProjectService`: `getMemberRoleInProject` 메소드를 추가하여 특정 멤버의 프로젝트 내 역할을 조회합니다.
    *   `CompanyProjectService`: `getCompanyRoleInProject` 메소드를 추가하여 특정 회사의 프로젝트 내 역할을 조회합니다.
3.  **프로젝트 조회 로직 수정 (`ProjectService`):**
    *   `getProject` 메소드가 현재 사용자 ID와 역할(`userRole`)을 받도록 시그니처를 변경했습니다.
    *   `mapToProjectResponse` 메소드에서 현재 사용자 정보를 기반으로 `MemberProjectService`와 `CompanyProjectService`의 역할 조회 메소드를 호출하고, 그 결과를 `ProjectResponse` DTO의 새 필드에 매핑합니다.
4.  **컨트롤러 수정 (`ProjectController`):**
    *   `getProject` 엔드포인트가 `HttpServletRequest`에서 현재 사용자의 `memberId`와 `userRole`을 추출하여 `ProjectService`로 전달하도록 수정했습니다. (인증 필터에서 해당 속성들이 설정된다고 가정)
5.  **Repository 메소드 추가:**
    *   `CompanyProjectRepository`와 `MemberProjectRepository`에 각각 회사/멤버와 프로젝트를 기반으로 삭제되지 않은 연관 관계를 조회하는 메소드(`findBy...AndIsDeletedFalse`)를 추가했습니다.

# 연관 이슈
#125

# Pull Request 체크리스트

## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
