### PR TITLE
[Fix] 승인요청 조회시 삭제된 데이터도 가져와지는 버그 수정

### DIFF
--- a/src/main/java/com/soda/request/repository/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/request/repository/RequestRepositoryImpl.java
@@ -45,7 +45,7 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
 
         JPQLQuery<Request> query = queryFactory
                 .selectFrom(request)
-                .where(builder)
+                .where(builder.and(request.isDeleted.eq(false)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 승인요청 조회시 삭제된 데이터도 가져오는 버그 수정 

# 연관 이슈
#131 

# 확인해야할 사항
- 승인요청 조회하는 API의 QueryDSL 메서드에서 where절에 조건 추가하여 해결하였습니다.

Closed #131 