### PR TITLE
[Feature] 승인요청 생성시 승인권자 지정 기능 개발

### DIFF
--- a/src/main/java/com/soda/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/soda/global/security/config/SecurityConfig.java
@@ -91,6 +91,8 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "https://soda-sooty.vercel.app",
+                "http://s0da.co.kr",
+                "https://s0da.co.kr",
                 "http://api.s0da.co.kr",
                 "https://api.s0da.co.kr"
         ));

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -10,6 +10,7 @@ import com.soda.common.link.service.LinkService;
 import com.soda.global.response.ApiResponseForm;
 import com.soda.request.dto.GetRequestCondition;
 import com.soda.request.dto.request.*;
+import com.soda.request.service.ApproverDesignationService;
 import com.soda.request.service.RequestService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RequestController {
     private final RequestService requestService;
+    private final ApproverDesignationService approverDesignationService;
     private final FileService fileService;
     private final LinkService linkService;
 
@@ -107,5 +109,13 @@ public class RequestController {
         Long memberId = (Long) request.getAttribute("memberId");
         LinkDeleteResponse linkDeleteResponse = linkService.delete("request", linkId, memberId);
         return ResponseEntity.ok(ApiResponseForm.success(linkDeleteResponse));
+    }
+
+    @DeleteMapping("requests/{requestId}/approver/{approverId}")
+    public ResponseEntity<ApiResponseForm<?>> deleteApprover(@PathVariable Long approverId,
+                                                             HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        ApproverDeleteResponse approverDeleteResponse = approverDesignationService.deleteApprover(approverId, memberId);
+        return ResponseEntity.ok(ApiResponseForm.success(approverDeleteResponse));
     }
 }

--- a/src/main/java/com/soda/request/dto/request/ApproverDTO.java
+++ b/src/main/java/com/soda/request/dto/request/ApproverDTO.java
@@ -1,0 +1,21 @@
+package com.soda.request.dto.request;
+
+import com.soda.request.entity.ApproverDesignation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApproverDTO {
+    private Long id;
+    private Long requestId;
+    private Long memberId;
+
+    public static ApproverDTO fromEntity(ApproverDesignation entity) {
+        return ApproverDTO.builder()
+                .id(entity.getId())
+                .requestId(entity.getRequest().getId())
+                .memberId(entity.getMember().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/soda/request/dto/request/ApproverDeleteResponse.java
+++ b/src/main/java/com/soda/request/dto/request/ApproverDeleteResponse.java
@@ -1,0 +1,23 @@
+package com.soda.request.dto.request;
+
+import com.soda.request.entity.ApproverDesignation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApproverDeleteResponse {
+    private Long id;
+    private Long requestId;
+    private Long memberId;
+    private Boolean isDeleted;
+
+    public static ApproverDeleteResponse fromEntity(ApproverDesignation approver) {
+        return ApproverDeleteResponse.builder()
+                .id(approver.getId())
+                .requestId(approver.getRequest().getId())
+                .memberId(approver.getMember().getId())
+                .isDeleted(approver.getIsDeleted())
+                .build();
+    }
+}

--- a/src/main/java/com/soda/request/dto/request/MemberAssignDTO.java
+++ b/src/main/java/com/soda/request/dto/request/MemberAssignDTO.java
@@ -1,0 +1,8 @@
+package com.soda.request.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberAssignDTO {
+    private Long id;
+}

--- a/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
@@ -14,11 +14,6 @@ public class RequestCreateRequest {
     private Long projectId;
     private Long stageId;
     private List<LinkUploadRequest.LinkUploadDTO> links;
-    private List<MemberDTO> members;
+    private List<MemberAssignDTO> members;
 
-    @Getter
-    @Setter
-    public static class MemberDTO {
-        private Long id;
-    }
 }

--- a/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
@@ -14,4 +14,11 @@ public class RequestCreateRequest {
     private Long projectId;
     private Long stageId;
     private List<LinkUploadRequest.LinkUploadDTO> links;
+    private List<MemberDTO> members;
+
+    @Getter
+    @Setter
+    public static class MemberDTO {
+        private Long id;
+    }
 }

--- a/src/main/java/com/soda/request/dto/request/RequestCreateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateResponse.java
@@ -21,6 +21,7 @@ public class RequestCreateResponse {
     private String title;
     private String content;
     private List<LinkDTO> links;
+    private List<ApproverDTO> approvers;
     private RequestStatus status;
     private LocalDateTime createdAt;
 
@@ -35,6 +36,11 @@ public class RequestCreateResponse {
                 .links(
                         request.getLinks().stream()
                                 .map(LinkDTO::fromEntity)
+                                .collect(Collectors.toList())
+                )
+                .approvers(
+                        request.getApprovers().stream()
+                                .map(ApproverDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )
                 .status(request.getStatus())

--- a/src/main/java/com/soda/request/dto/request/RequestDTO.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDTO.java
@@ -22,6 +22,7 @@ public class RequestDTO {
     private String content;
     private List<LinkDTO> links;
     private List<FileDTO> files;
+    private List<ApproverDTO> approvers;
     private RequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -45,6 +46,11 @@ public class RequestDTO {
                         request.getFiles().stream()
                                 .filter(file -> !file.getIsDeleted())
                                 .map(FileDTO::fromEntity)
+                                .collect(Collectors.toList())
+                )
+                .approvers(
+                        request.getApprovers().stream()
+                                .map(ApproverDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )
                 .status(request.getStatus())

--- a/src/main/java/com/soda/request/dto/request/RequestUpdateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestUpdateRequest.java
@@ -10,6 +10,7 @@ public class RequestUpdateRequest {
     private String title;
     private String content;
     private List<LinkUploadRequest.LinkUploadDTO> links;
+    private List<MemberAssignDTO> members;
 
     @Getter
     public static class LinkUploadDTO {

--- a/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
@@ -20,6 +20,7 @@ public class RequestUpdateResponse {
     private String title;
     private String content;
     private List<LinkDTO> links;
+    private List<ApproverDTO> approvers;
     private RequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -35,6 +36,11 @@ public class RequestUpdateResponse {
                 .links(
                         request.getLinks().stream()
                                 .map(LinkDTO::fromEntity)
+                                .collect(Collectors.toList())
+                )
+                .approvers(
+                        request.getApprovers().stream()
+                                .map(ApproverDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )
                 .status(request.getStatus())

--- a/src/main/java/com/soda/request/entity/ApproverDesignation.java
+++ b/src/main/java/com/soda/request/entity/ApproverDesignation.java
@@ -7,8 +7,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,4 +26,19 @@ public class ApproverDesignation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public ApproverDesignation(Request request, Member member) {
+        this.request = request;
+        this.member = member;
+    }
+
+    public static List<ApproverDesignation> designateApprover(Request request, List<Member> members) {
+        return members.stream()
+                .map(member -> ApproverDesignation.builder()
+                        .request(request)
+                        .member(member)
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/soda/request/entity/ApproverDesignation.java
+++ b/src/main/java/com/soda/request/entity/ApproverDesignation.java
@@ -41,4 +41,8 @@ public class ApproverDesignation extends BaseEntity {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    public void delete() {
+        markAsDeleted();
+    }
 }

--- a/src/main/java/com/soda/request/entity/ApproverDesignation.java
+++ b/src/main/java/com/soda/request/entity/ApproverDesignation.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class DesignateApprover extends BaseEntity {
+public class ApproverDesignation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "request_id")

--- a/src/main/java/com/soda/request/entity/DesignateApprover.java
+++ b/src/main/java/com/soda/request/entity/DesignateApprover.java
@@ -1,0 +1,25 @@
+package com.soda.request.entity;
+
+import com.soda.common.BaseEntity;
+import com.soda.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DesignateApprover extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id")
+    private Request request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -94,4 +94,11 @@ public class Request extends BaseEntity {
     public void changeStatusToPending() {
         this.status = RequestStatus.PENDING;
     }
+
+    public void addApprovers(List<ApproverDesignation> approverDesignations) {
+        if (this.approvers == null) {
+            this.approvers = new ArrayList<>();
+        }
+        this.approvers.addAll(approverDesignations);
+    }
 }

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -45,6 +45,10 @@ public class Request extends BaseEntity {
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
     private List<RequestLink> links;
 
+    @TrackUpdate
+    @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    private List<ApproverDesignation> approvers;
+
     @Builder
     public Request(Member member, Stage stage, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
         this.member = member;

--- a/src/main/java/com/soda/request/error/ApproverDesignationErrorCode.java
+++ b/src/main/java/com/soda/request/error/ApproverDesignationErrorCode.java
@@ -1,0 +1,35 @@
+package com.soda.request.error;
+
+import com.soda.global.response.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ApproverDesignationErrorCode implements ErrorCode {
+
+    APPROVE_NOT_FOUND("3401", "ApproveDesignation not found", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ApproverDesignationErrorCode (String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/soda/request/error/RequestErrorCode.java
+++ b/src/main/java/com/soda/request/error/RequestErrorCode.java
@@ -10,6 +10,7 @@ public enum RequestErrorCode implements ErrorCode {
     USER_NOT_UPLOAD_FILE("3004", "This user didn't upload the request_file", HttpStatus.BAD_REQUEST),
     REQUEST_LINK_NOT_FOUND("3005", "This request_link is not found" , HttpStatus.NOT_FOUND ),
     USER_NOT_UPLOAD_LINK("3006", "This user didn't upload the request_link" , HttpStatus.BAD_REQUEST ),
+    USER_IS_NOT_APPROVER("3007", "This user is not approver", HttpStatus.BAD_REQUEST ),
     ;
 
     private final String code;

--- a/src/main/java/com/soda/request/repository/ApproverDesignationRepository.java
+++ b/src/main/java/com/soda/request/repository/ApproverDesignationRepository.java
@@ -1,0 +1,9 @@
+package com.soda.request.repository;
+
+import com.soda.request.entity.ApproverDesignation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApproverDesignationRepository extends JpaRepository<ApproverDesignation, Long> {
+}

--- a/src/main/java/com/soda/request/service/ApproverDesignationService.java
+++ b/src/main/java/com/soda/request/service/ApproverDesignationService.java
@@ -1,0 +1,42 @@
+package com.soda.request.service;
+
+import com.soda.global.response.GeneralException;
+import com.soda.request.dto.request.ApproverDeleteResponse;
+import com.soda.request.entity.ApproverDesignation;
+import com.soda.request.error.ApproverDesignationErrorCode;
+import com.soda.request.error.RequestErrorCode;
+import com.soda.request.repository.ApproverDesignationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ApproverDesignationService {
+    private final ApproverDesignationRepository approverDesignationRepository;
+
+    @Transactional
+    public ApproverDeleteResponse deleteApprover(Long approverId, Long memberId) {
+        ApproverDesignation approver = getApproveDesignationOrThrow(approverId);
+
+        // 현재 유저가 승인 생성자이닞 확인
+        validateRequestWriter(memberId, approver);
+
+        // request 소프트 삭제
+        approver.delete();
+
+        return ApproverDeleteResponse.fromEntity(approver);
+    }
+
+    private void validateRequestWriter(Long memberId, ApproverDesignation approver) {
+        if(!approver.getRequest().getMember().getId().equals(memberId)) {
+            throw new GeneralException(RequestErrorCode.USER_NOT_WRITE_REQUEST);
+        }
+    }
+
+    private ApproverDesignation getApproveDesignationOrThrow(Long approverId) {
+        return approverDesignationRepository.findById(approverId)
+                .orElseThrow(() -> new GeneralException(ApproverDesignationErrorCode.APPROVE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -191,12 +191,16 @@ public class RequestService {
     }
 
     private void designateApprover(List<MemberAssignDTO> dtos, Request request) {
-        List<Member> approvers = dtos.stream()
-                .map(memberDTO -> {
-                    return memberRepository.findById(memberDTO.getId())
-                            .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
-                })
+        List<Long> memberIds = dtos.stream()
+                .map(MemberAssignDTO::getId)
                 .collect(Collectors.toList());
+
+        List<Member> approvers = memberRepository.findAllById(memberIds);
+
+        if (approvers.size() != memberIds.size()) {
+            throw new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+        }
+
         request.addApprovers(ApproverDesignation.designateApprover(request, approvers));
     }
 

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -16,10 +16,12 @@ import com.soda.project.error.StageErrorCode;
 import com.soda.project.repository.StageRepository;
 import com.soda.request.dto.GetRequestCondition;
 import com.soda.request.dto.request.*;
+import com.soda.request.entity.ApproverDesignation;
 import com.soda.request.entity.Request;
 import com.soda.request.entity.RequestLink;
 import com.soda.request.enums.RequestStatus;
 import com.soda.request.error.RequestErrorCode;
+import com.soda.request.repository.ApproverDesignationRepository;
 import com.soda.request.repository.RequestLinkRepository;
 import com.soda.request.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,7 @@ public class RequestService {
     private final MemberRepository memberRepository;
     private final StageRepository stageRepository;
     private final RequestLinkRepository requestLinkRepository;
+    private final ApproverDesignationRepository approverDesignationRepository;
 
     /*
     Request(승인요청) 생성
@@ -180,7 +183,18 @@ public class RequestService {
         Request request = buildRequest(dto, member, stage);
         List<RequestLink> requestLinks = linkService.buildLinks("request", request, dto.getLinks());
         request.addLinks(requestLinks);
+        designateApprover(dto, request);
         return requestRepository.save(request);
+    }
+
+    private void designateApprover(RequestCreateRequest dto, Request request) {
+        List<Member> approvers = dto.getMembers().stream()
+                .map(memberDTO -> {
+                    return memberRepository.findById(memberDTO.getId())
+                            .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
+                })
+                .collect(Collectors.toList());
+        approverDesignationRepository.saveAll(ApproverDesignation.designateApprover(request, approvers));
     }
 
     private Request buildRequest(RequestCreateRequest dto, Member member, Stage stage) {

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -197,7 +197,7 @@ public class RequestService {
                             .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
                 })
                 .collect(Collectors.toList());
-        approverDesignationRepository.saveAll(ApproverDesignation.designateApprover(request, approvers));
+        request.addApprovers(ApproverDesignation.designateApprover(request, approvers));
     }
 
     private Request buildRequest(RequestCreateRequest dto, Member member, Stage stage) {

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -177,18 +177,21 @@ public class RequestService {
         if(requestUpdateRequest.getLinks() != null) {
             request.addLinks(linkService.buildLinks("request", request, requestUpdateRequest.getLinks()));
         }
+        if(requestUpdateRequest.getMembers() != null) {
+            designateApprover(requestUpdateRequest.getMembers(), request);
+        }
     }
 
     public Request createRequest(RequestCreateRequest dto, Member member, Stage stage) {
         Request request = buildRequest(dto, member, stage);
         List<RequestLink> requestLinks = linkService.buildLinks("request", request, dto.getLinks());
         request.addLinks(requestLinks);
-        designateApprover(dto, request);
+        designateApprover(dto.getMembers(), request);
         return requestRepository.save(request);
     }
 
-    private void designateApprover(RequestCreateRequest dto, Request request) {
-        List<Member> approvers = dto.getMembers().stream()
+    private void designateApprover(List<MemberAssignDTO> dtos, Request request) {
+        List<Member> approvers = dtos.stream()
                 .map(memberDTO -> {
                     return memberRepository.findById(memberDTO.getId())
                             .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 승인요청 생성시 승인권자 지정 기능 개발

# 연관 이슈
#141 

# 확인해야할 사항
- 승인요청 - 멤버 중간테이블 생성
  - 승인요청에 대해 여러명의 승인권자를 지정할 수 있어 다대다매핑이 되어 중간테이블을 생성함
  - 그 의미를 함축하도록 ApproverDesignation이라고 테이블명을 네이밍함
- 승인요청 생성/수정 시 승인권자를 여러 명 지정할 수 있게 구현하였음
- 승인요청 상세조회시 DTO에 승인권자들도 반환됨
- 승인요청에 대해 승인/거절 생성시 요청한 사람이 승인권자인지 validate함.
- approverDesignation 삭제하는 API도 구현

Closed #141 