### PR TITLE
[Fix] 삭제된 승인권자가 조회되는 버그 해결

### DIFF
--- a/src/main/java/com/soda/request/dto/request/RequestDTO.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDTO.java
@@ -50,6 +50,7 @@ public class RequestDTO {
                 )
                 .approvers(
                         request.getApprovers().stream()
+                                .filter(approver -> !approver.getIsDeleted())
                                 .map(ApproverDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 삭제된 승인권자가 조회되는 버그 해결

# 연관 이슈
#141 

# 확인해야할 사항
- #141 에서 승인권자를 삭제하였음에도 승인요청 상세조회시 삭제된 승인권자가 조회되는 버그를 해결하였습니다.
  - Request 조회 응답 DTO에서 approver를 출력할 때 isDeleted=false 필터링하는 방식으로 해결하였습니다.