### PR TITLE
[CICD & FIX] cors에 프론트 url 오타 정정(www를 빠뜨림)

### DIFF
--- a/src/main/java/com/soda/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/soda/global/security/config/SecurityConfig.java
@@ -91,8 +91,8 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "https://soda-sooty.vercel.app",
-                "http://s0da.co.kr",
-                "https://s0da.co.kr",
+                "http://www.s0da.co.kr",
+                "https://www.s0da.co.kr",
                 "http://api.s0da.co.kr",
                 "https://api.s0da.co.kr"
         ));


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- CORS 설정 중 프론트 url에 www를 빠뜨린 오타를 정정하였음

# 연관 이슈
Closed #145 