### PR TITLE
[Feature] 프로젝트 CRUD 일부 구현

### DIFF
--- a/src/main/java/com/soda/member/enums/CompanyProjectRole.java
+++ b/src/main/java/com/soda/member/enums/CompanyProjectRole.java
@@ -4,14 +4,17 @@ import lombok.Getter;
 
 @Getter
 public enum CompanyProjectRole {
-    DEV_COMPANY("개발사"),
-    CLIENT_COMPANY("고객사")
-    ;
+    DEV_COMPANY("개발사", MemberProjectRole.DEV_MANAGER, MemberProjectRole.DEV_PARTICIPANT),
+    CLIENT_COMPANY("고객사", MemberProjectRole.CLI_MANAGER, MemberProjectRole.CLI_PARTICIPANT);
 
     private final String description;
+    private final MemberProjectRole managerRole;
+    private final MemberProjectRole memberRole;
 
-    CompanyProjectRole(String description) {
+    CompanyProjectRole(String description, MemberProjectRole managerRole, MemberProjectRole memberRole) {
         this.description = description;
+        this.managerRole = managerRole;
+        this.memberRole = memberRole;
     }
 
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -85,4 +85,12 @@ public class ProjectController {
         ProjectInfoUpdateResponse response = projectService.updateProjectInfo(userRole, projectId, projectInfoUpdateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트 기본 정보 수정 성공"));
     }
+
+    @PostMapping("/{projectId}/companies")
+    public ResponseEntity<ApiResponseForm<ProjectCompanyAddResponse>> addCompanyToProject (HttpServletRequest request, @PathVariable Long projectId,
+                                                                   @Valid @RequestBody ProjectCompanyAddRequest projectCompanyAddRequest) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectCompanyAddResponse response = projectService.addCompanyToProject(userRole, projectId, projectCompanyAddRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트에 새로운 회사/멤버 추가 성공"));
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -77,4 +77,12 @@ public class ProjectController {
         projectService.deleteProject(projectId);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ApiResponseForm<ProjectInfoUpdateResponse>> updateProjectInfo(HttpServletRequest request, @PathVariable Long projectId,
+                                                                @Valid @RequestBody ProjectInfoUpdateRequest projectInfoUpdateRequest) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectInfoUpdateResponse response = projectService.updateProjectInfo(userRole, projectId, projectInfoUpdateRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트 기본 정보 수정 성공"));
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -61,4 +61,13 @@ public class ProjectController {
         ProjectViewResponse response = projectService.getProject(userId, userRole, projectId);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
+
+    @PatchMapping("/{projectId}/status")
+    public ResponseEntity<ApiResponseForm<ProjectStatusUpdateResponse>> updateProjectStatus(HttpServletRequest request, @PathVariable Long projectId,
+                                                                                            @Valid @RequestBody ProjectStatusUpdateRequest updateRequest) {
+        Long userId = (Long) request.getAttribute("memberId");
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectStatusUpdateResponse response = projectService.updateProjectStatus(userId, userRole, projectId, updateRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트 상태 변경 성공"));
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -70,4 +70,11 @@ public class ProjectController {
         ProjectStatusUpdateResponse response = projectService.updateProjectStatus(userId, userRole, projectId, updateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트 상태 변경 성공"));
     }
+
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<Void> deleteProject(HttpServletRequest request, @PathVariable Long projectId) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        projectService.deleteProject(projectId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -53,4 +53,12 @@ public class ProjectController {
         Page<ProjectListResponse> response = projectService.getMyProjects(userId, userRole, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ApiResponseForm<ProjectViewResponse>> getProject(HttpServletRequest request, @PathVariable Long projectId) {
+        Long userId = (Long) request.getAttribute("memberId");
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectViewResponse response = projectService.getProject(userId, userRole, projectId);
+        return ResponseEntity.ok(ApiResponseForm.success(response));
+    }
 }

--- a/src/main/java/com/soda/project/dto/ProjectCompanyAddRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectCompanyAddRequest.java
@@ -1,0 +1,22 @@
+package com.soda.project.dto;
+
+import com.soda.member.enums.CompanyProjectRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProjectCompanyAddRequest {
+
+    @NotNull(message = "회사 ID는 필수입니다.")
+    private Long companyId;
+
+    @NotNull(message = "회사 역할은 필수입니다. (고객사/개발사")
+    private CompanyProjectRole role;
+
+    @NotNull(message = "담당자 선택은 필수입니다.")
+    private List<Long> managerIds;
+
+    private List<Long> memberIds;
+}

--- a/src/main/java/com/soda/project/dto/ProjectCompanyAddResponse.java
+++ b/src/main/java/com/soda/project/dto/ProjectCompanyAddResponse.java
@@ -1,0 +1,42 @@
+package com.soda.project.dto;
+
+import com.soda.member.entity.Company;
+import com.soda.member.entity.Member;
+import com.soda.member.enums.CompanyProjectRole;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ProjectCompanyAddResponse {
+
+    private Long id;
+    private String companyName;
+    private CompanyProjectRole role;
+
+    private List<String> managerNames;
+    private List<String> memberNames;
+
+    public static ProjectCompanyAddResponse from (
+            Long projectId,
+            Company addedCompany,
+            CompanyProjectRole addedRole,
+            List<Member> addedManagers,
+            List<Member> addedMembers
+    ) {
+        return ProjectCompanyAddResponse.builder()
+                .id(projectId)
+                .companyName(addedCompany.getName())
+                .role(addedRole)
+                .managerNames(addedManagers.stream()
+                        .map(Member::getName)
+                        .collect(Collectors.toList()))
+                .memberNames(addedMembers.stream()
+                        .map(Member::getName)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/soda/project/dto/ProjectInfoUpdateRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectInfoUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.soda.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProjectInfoUpdateRequest {
+
+    @NotBlank(message = "프로젝트 제목은 필수입니다.")
+    @Size(max = 255, message = "프로젝트 제목은 255자를 넘을 수 없습니다.")
+    private String title;
+
+    @Size(max = 5000, message = "프로젝트 설명은 5000자를 넘을 수 없습니다.")
+    private String description;
+
+    @NotNull(message = "시작일은 필수입니다.")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "종료일은 필수입니다.")
+    private LocalDateTime endDate;
+
+}

--- a/src/main/java/com/soda/project/dto/ProjectInfoUpdateResponse.java
+++ b/src/main/java/com/soda/project/dto/ProjectInfoUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.soda.project.dto;
+
+import com.soda.project.entity.Project;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ProjectInfoUpdateResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    public static ProjectInfoUpdateResponse from(Project project) {
+        return ProjectInfoUpdateResponse.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/com/soda/project/dto/ProjectStatusUpdateRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.soda.project.dto;
+
+import com.soda.project.enums.ProjectStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectStatusUpdateRequest {
+
+    @NotNull(message = "반경할 프로젝트 상태는 필수입니다.")
+    private ProjectStatus status;
+
+}

--- a/src/main/java/com/soda/project/dto/ProjectStatusUpdateResponse.java
+++ b/src/main/java/com/soda/project/dto/ProjectStatusUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.soda.project.dto;
+
+import com.soda.project.entity.Project;
+import com.soda.project.enums.ProjectStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectStatusUpdateResponse {
+
+    private Long projectId;
+    private ProjectStatus status;
+
+    public static ProjectStatusUpdateResponse from (Project project) {
+        return ProjectStatusUpdateResponse.builder()
+                .projectId(project.getId())
+                .status(project.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/soda/project/dto/ProjectViewResponse.java
+++ b/src/main/java/com/soda/project/dto/ProjectViewResponse.java
@@ -1,0 +1,65 @@
+package com.soda.project.dto;
+
+import com.soda.project.entity.Project;
+import com.soda.project.enums.ProjectStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ProjectViewResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private ProjectStatus status;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    // 현재 로그인한 사용자의 역할 (개발사 또는 고객사 / 담당자 또는 일반 참여자)
+    private String currentUserProjectRole;
+    private String currentUserCompanyRole;
+
+    // 고객사 정보
+    private List<String> clientCompanyNames;
+    private List<String> clientManagers;
+    private List<String> clientMembers;
+
+    // 개발사
+    private List<String> devCompanyNames;
+    private List<String> devManagers;
+    private List<String> devMembers;
+
+    public static ProjectViewResponse from(
+            Project project,
+            String currentUserProjectRole,
+            String currentUserCompanyRole,
+            List<String> clientCompanyNames,
+            List<String> clientManagers,
+            List<String> clientMembers,
+            List<String> devCompanyNames,
+            List<String> devManagers,
+            List<String> devMembers
+    ) {
+        return ProjectViewResponse.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .status(project.getStatus())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .currentUserProjectRole((currentUserProjectRole))
+                .currentUserCompanyRole(currentUserCompanyRole)
+                .clientCompanyNames(clientCompanyNames)
+                .clientManagers(clientManagers)
+                .clientMembers(clientMembers)
+                .devCompanyNames(devCompanyNames)
+                .devManagers(devManagers)
+                .devMembers(devMembers)
+                .build();
+    }
+
+}

--- a/src/main/java/com/soda/project/entity/Project.java
+++ b/src/main/java/com/soda/project/entity/Project.java
@@ -52,12 +52,11 @@ public class Project extends BaseEntity {
         this.markAsDeleted();
     }
 
-    public void updateProject(String title, String description, LocalDateTime startDate, LocalDateTime endDate,ProjectStatus status) {
+    public void updateProjectInfo(String title, String description, LocalDateTime startDate, LocalDateTime endDate) {
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.status = status;
     }
 
     public void changeStatus(ProjectStatus newStatus) {

--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -13,7 +13,7 @@ public enum ProjectErrorCode implements ErrorCode {
     INVALID_DATE_RANGE("1007","Invalid date range: The end date cannot be before the start date" ,HttpStatus.NOT_FOUND ),
     UNAUTHORIZED_USER("1008", "Unauthorized: Only ADMIN users can create a project.", HttpStatus.FORBIDDEN),
     NO_PERMISSION_TO_UPDATE_STATUS("1009", "Unauthorized: You do not have permission to update the project status.", HttpStatus.FORBIDDEN),
-    ;
+    INVALID_COMPANY_ROLE("1010", "This Company role does not exist", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -7,13 +7,13 @@ public enum ProjectErrorCode implements ErrorCode {
     COMPANY_NOT_FOUND("1001", "Company not found: The specified company does not exist.", HttpStatus.NOT_FOUND),
     MEMBER_NOT_FOUND("1002", "Member not found: The specified member does not exist.", HttpStatus.NOT_FOUND),
     INVALID_MEMBER_COMPANY("1003", "Invalid member company: The member does not belong to the specified company.", HttpStatus.BAD_REQUEST),
-    PROJECT_TITLE_DUPLICATED("1004", "Project title is duplicated: A project with the same title already exists.", HttpStatus.BAD_REQUEST),
-    PROJECT_NOT_FOUND("1005", "Invalid project Id", HttpStatus.NOT_FOUND),
-    PROJECT_ALREADY_DELETED("1006", "This Project is already deleted", HttpStatus.NOT_FOUND),
-    INVALID_STAGE_FOR_PROJECT("1007", "Invalid stage for project", HttpStatus.NOT_FOUND),
-    MEMBER_NOT_IN_PROJECT("1008", "This member does not exist in this project", HttpStatus.NOT_FOUND),
-    INVALID_DATE_RANGE("1009","Invalid date range: The end date cannot be before the start date" ,HttpStatus.NOT_FOUND ),
-    UNAUTHORIZED_USER("1010", "Unauthorized: Only ADMIN users can create a project.", HttpStatus.FORBIDDEN);;
+    PROJECT_NOT_FOUND("1004", "Invalid project Id", HttpStatus.NOT_FOUND),
+    INVALID_STAGE_FOR_PROJECT("1005", "Invalid stage for project", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_IN_PROJECT("1006", "This member does not exist in this project", HttpStatus.NOT_FOUND),
+    INVALID_DATE_RANGE("1007","Invalid date range: The end date cannot be before the start date" ,HttpStatus.NOT_FOUND ),
+    UNAUTHORIZED_USER("1008", "Unauthorized: Only ADMIN users can create a project.", HttpStatus.FORBIDDEN),
+    NO_PERMISSION_TO_UPDATE_STATUS("1009", "Unauthorized: You do not have permission to update the project status.", HttpStatus.FORBIDDEN),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -421,4 +421,19 @@ public class ProjectService {
         log.warn("프로젝트 상태 변경 권한 없음: userId={}, userRole={}, projectId={}", member.getId(), userRole, project.getId());
         throw new GeneralException(ProjectErrorCode.NO_PERMISSION_TO_UPDATE_STATUS);
     }
+
+    @LoggableEntityAction(action = "DELETE", entityClass = Project.class)
+    @Transactional
+    public void deleteProject(Long projectId) {
+        // 프로젝트 유효성 검사
+        Project project = getValidProject(projectId);
+
+        // TODO ADMIN만 프로젝트 삭제 가능 (로그 오류 발생해서 추후 수정 가능하면 유효성 검사 추가 예정)
+        //validateAdminRole(userRole);
+
+        // 프로젝트 삭제 (연관된 memberProject, companyProject 함께 삭제)
+        project.delete();
+        companyProjectService.deleteCompanyProjects(project);
+        memberProjectService.deleteMemberProjects(project);
+    }
 }


### PR DESCRIPTION

# 요약

- 프로젝트 개별 조회 API
- 프로젝트 삭제 API
- 프로젝트 상태 변경 API
- 프로젝트 기본 정보 수정 API
- 프로젝트에 새로운 회사/멤버 추가 API


# 연관 이슈

#138 


# 확인 사항
### 1. `CompanyProjectRole` enum 변경
- 프로젝트에 고객사 또는 개발사를 추가하는 API를 개발하는 과정에서 company role과 member role이 연관되어야 한다는걸 깨달았습니다.
- 그래서 enum 파일을 리팩토링하였습니다.
- CompanyProjectRole 열거형을 사용하면 코드가 더 직관적이고 명확해집니다. 
   - 예를 들어, DEV_COMPANY와 CLIENT_COMPANY 역할에 각각 맞는 managerRole과 memberRole을 열거형 내에서 정의함으로써, 다른 코드에서 이를 참조할 때 훨씬 쉽게 이해할 수 있습니다.
- 회사의 역할에 따른 멤버 역할이 자동으로 매핑되고, 이를 기반으로 일관된 로직을 적용할 수 있습니다.
### 2. 프로젝트 기본 정보 수정 API 생성
- 기존에는 프로젝트 수정 시 기본 정보 / 개발사&고객사 수정을 한꺼번에 하도록 구현하였습니다.
- 그러나 기획 회의에서 분리하였으면 좋겠다는 의견을 수렴해 우선 기본 정보 수정하는 API로 수정하였습니다.
- 추후 고객사/개발사 선택, 멤버 선택하는 API를 추가할 예정입니다.