### PR TITLE
[Feature] 프로젝트 참여 회사/멤버 관리 기능 구현

### DIFF
--- a/src/main/java/com/soda/member/enums/CompanyProjectRole.java
+++ b/src/main/java/com/soda/member/enums/CompanyProjectRole.java
@@ -4,17 +4,13 @@ import lombok.Getter;
 
 @Getter
 public enum CompanyProjectRole {
-    DEV_COMPANY("개발사", MemberProjectRole.DEV_MANAGER, MemberProjectRole.DEV_PARTICIPANT),
-    CLIENT_COMPANY("고객사", MemberProjectRole.CLI_MANAGER, MemberProjectRole.CLI_PARTICIPANT);
+    DEV_COMPANY("개발사"),
+    CLIENT_COMPANY("고객사");
 
     private final String description;
-    private final MemberProjectRole managerRole;
-    private final MemberProjectRole memberRole;
 
-    CompanyProjectRole(String description, MemberProjectRole managerRole, MemberProjectRole memberRole) {
+    CompanyProjectRole(String description) {
         this.description = description;
-        this.managerRole = managerRole;
-        this.memberRole = memberRole;
     }
 
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -107,6 +107,6 @@ public class ProjectController {
                                                                    @Valid @RequestBody ProjectMemberAddRequest projectMemberAddRequest) {
         String userRole = (String) request.getAttribute("userRole").toString();
         ProjectMemberAddResponse response = projectService.addMemberToProject(userRole, projectId, projectMemberAddRequest);
-        return null;
+        return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트에 멤버 추가 성공"));
     }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -101,4 +101,12 @@ public class ProjectController {
         projectService.deleteCompanyFromProject(userRole, projectId, companyId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{projectId}/members")
+    public ResponseEntity<ApiResponseForm<ProjectMemberAddResponse>> addMembersToProject (HttpServletRequest request, @PathVariable Long projectId,
+                                                                   @Valid @RequestBody ProjectMemberAddRequest projectMemberAddRequest) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        ProjectMemberAddResponse response = projectService.addMemberToProject(userRole, projectId, projectMemberAddRequest);
+        return null;
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -109,4 +109,11 @@ public class ProjectController {
         ProjectMemberAddResponse response = projectService.addMemberToProject(userRole, projectId, projectMemberAddRequest);
         return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트에 멤버 추가 성공"));
     }
+
+    @DeleteMapping("/{projectId}/members/{memberId}")
+    public ResponseEntity<Void> deleteMemberFromProject (HttpServletRequest request, @PathVariable Long projectId, @PathVariable Long memberId) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        projectService.deleteMemberFromProject(userRole, projectId, memberId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -93,4 +93,12 @@ public class ProjectController {
         ProjectCompanyAddResponse response = projectService.addCompanyToProject(userRole, projectId, projectCompanyAddRequest);
         return ResponseEntity.ok(ApiResponseForm.success(response, "프로젝트에 새로운 회사/멤버 추가 성공"));
     }
+
+    @DeleteMapping("/{projectId}/companies/{companyId}")
+    public ResponseEntity<Void> deleteCompanyFromProject(@PathVariable Long projectId,
+                                                         @PathVariable Long companyId, HttpServletRequest request) {
+        String userRole = (String) request.getAttribute("userRole").toString();
+        projectService.deleteCompanyFromProject(userRole, projectId, companyId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/soda/project/dto/ProjectMemberAddRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectMemberAddRequest.java
@@ -1,0 +1,18 @@
+package com.soda.project.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProjectMemberAddRequest {
+
+    @NotNull(message = "멤버를 추가할 회사 ID는 필수입니다.")
+    private Long companyId;
+
+    // 둘 중 하나만 추가 가능
+    private List<Long> managerIds;
+    private List<Long> memberIds;
+
+}

--- a/src/main/java/com/soda/project/dto/ProjectMemberAddResponse.java
+++ b/src/main/java/com/soda/project/dto/ProjectMemberAddResponse.java
@@ -1,0 +1,31 @@
+package com.soda.project.dto;
+
+import com.soda.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ProjectMemberAddResponse {
+
+    private Long projectId;
+    private String companyName;
+    private List<String> managerNames;
+    private List<String> memberNames;
+
+    public static ProjectMemberAddResponse from (Long projectId, String companyName, List<Member> managers, List<Member> members) {
+        return ProjectMemberAddResponse.builder()
+                .projectId(projectId)
+                .companyName(companyName)
+                .managerNames(managers.stream()
+                        .map(Member::getName)
+                        .collect(Collectors.toList()))
+                .memberNames(members.stream()
+                        .map(Member::getName)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -4,7 +4,7 @@ import com.soda.global.response.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum ProjectErrorCode implements ErrorCode {
-    COMPANY_NOT_FOUND("1001", "Company not found: The specified company does not exist.", HttpStatus.NOT_FOUND),
+    COMPANY_PROJECT_NOT_FOUND("1001", "Company not found: The specified company does not exist.", HttpStatus.NOT_FOUND),
     MEMBER_NOT_FOUND("1002", "Member not found: The specified member does not exist.", HttpStatus.NOT_FOUND),
     INVALID_MEMBER_COMPANY("1003", "Invalid member company: The member does not belong to the specified company.", HttpStatus.BAD_REQUEST),
     PROJECT_NOT_FOUND("1004", "Invalid project Id", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -13,7 +13,8 @@ public enum ProjectErrorCode implements ErrorCode {
     INVALID_DATE_RANGE("1007","Invalid date range: The end date cannot be before the start date" ,HttpStatus.NOT_FOUND ),
     UNAUTHORIZED_USER("1008", "Unauthorized: Only ADMIN users can create a project.", HttpStatus.FORBIDDEN),
     NO_PERMISSION_TO_UPDATE_STATUS("1009", "Unauthorized: You do not have permission to update the project status.", HttpStatus.FORBIDDEN),
-    INVALID_COMPANY_ROLE("1010", "This Company role does not exist", HttpStatus.NOT_FOUND);
+    MEMBER_LIST_EMPTY("1010", "Either manager or participant member list must be provided.", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_IN_SPECIFIED_COMPANY ("1011", "One or more requested members do not belong to the specified company.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -14,7 +14,8 @@ public enum ProjectErrorCode implements ErrorCode {
     UNAUTHORIZED_USER("1008", "Unauthorized: Only ADMIN users can create a project.", HttpStatus.FORBIDDEN),
     NO_PERMISSION_TO_UPDATE_STATUS("1009", "Unauthorized: You do not have permission to update the project status.", HttpStatus.FORBIDDEN),
     MEMBER_LIST_EMPTY("1010", "Either manager or participant member list must be provided.", HttpStatus.NOT_FOUND),
-    MEMBER_NOT_IN_SPECIFIED_COMPANY ("1011", "One or more requested members do not belong to the specified company.", HttpStatus.BAD_REQUEST);
+    MEMBER_NOT_IN_SPECIFIED_COMPANY ("1011", "One or more requested members do not belong to the specified company.", HttpStatus.BAD_REQUEST),
+    MEMBER_PROJECT_NOT_FOUND("1012", "Invalid member project", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
@@ -21,4 +21,6 @@ public interface CompanyProjectRepository extends JpaRepository<CompanyProject, 
     Optional<CompanyProject> findByCompanyAndProjectAndIsDeletedFalse(Company company, Project project);
 
     List<CompanyProject> findByProjectAndCompanyProjectRoleAndIsDeletedFalse(Project project, CompanyProjectRole role);
+
+    Optional<CompanyProject> findByProjectIdAndCompanyIdAndIsDeletedFalse(Long projectId, Long companyId);
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -34,4 +34,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     Optional<MemberProject> findByMemberAndProjectAndIsDeletedFalse(Member member, Project project);
 
     List<MemberProject> findAllByProjectAndMember_CompanyIdAndIsDeletedFalse(Project project, Long companyId);
+
+    Optional<MemberProject> findByProjectAndMemberIdAndIsDeletedFalse(Project project, Long memberId);
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -32,4 +32,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     Page<MemberProject> findByMemberId(Long userId, Pageable pageable);
 
     Optional<MemberProject> findByMemberAndProjectAndIsDeletedFalse(Member member, Project project);
+
+    List<MemberProject> findAllByProjectAndMember_CompanyIdAndIsDeletedFalse(Project project, Long companyId);
 }

--- a/src/main/java/com/soda/project/service/CompanyProjectService.java
+++ b/src/main/java/com/soda/project/service/CompanyProjectService.java
@@ -72,7 +72,7 @@ public class CompanyProjectService {
 
     private CompanyProject findByProjectAndCompanyProjectRole(Project project, CompanyProjectRole role) {
         return companyProjectRepository.findByProjectAndCompanyProjectRole(project, role)
-                .orElseThrow(() -> new GeneralException(ProjectErrorCode.COMPANY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND));
     }
 
     /**
@@ -84,5 +84,14 @@ public class CompanyProjectService {
     public CompanyProjectRole getCompanyRoleInProject(Company company, Project project) {
         Optional<CompanyProject> companyProjectOpt = companyProjectRepository.findByCompanyAndProjectAndIsDeletedFalse(company, project);
         return companyProjectOpt.map(CompanyProject::getCompanyProjectRole).orElse(null);
+    }
+
+    public void deleteCompanyFromProject(Project project, Long companyId) {
+
+        CompanyProject companyProject = companyProjectRepository.findByProjectIdAndCompanyIdAndIsDeletedFalse(project.getId(), companyId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND));
+
+        companyProject.delete();
+        log.info("프로젝트 ID {} 에서 회사 ID {} 삭제 완료", project.getId(), companyId);
     }
 }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -113,4 +113,21 @@ public class MemberProjectService {
         Optional<MemberProject> memberProjectOpt = memberProjectRepository.findByMemberAndProjectAndIsDeletedFalse(member, project);
         return memberProjectOpt.map(MemberProject::getRole).orElse(null);
     }
+
+    @Transactional
+    public void deleteMembersFromProject(Project project, Long companyId) {
+        List<MemberProject> membersToDelete = memberProjectRepository
+                .findAllByProjectAndMember_CompanyIdAndIsDeletedFalse(project, companyId);
+
+        if (membersToDelete.isEmpty()) {
+            log.info("삭제할 멤버 연결 없음: projectId={}, companyId={}", project.getId(), companyId);
+            return; // 처리할 대상 없으면 종료
+        }
+
+        for (MemberProject memberProject: membersToDelete) {
+            memberProject.delete();
+        }
+
+        log.info("멤버 {}명이 프로젝트 ID {} 에서 삭제되었습니다.", membersToDelete.size(), project.getId());
+    }
 }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -118,12 +118,7 @@ public class MemberProjectService {
     public void deleteMembersFromProject(Project project, Long companyId) {
         List<MemberProject> membersToDelete = memberProjectRepository
                 .findAllByProjectAndMember_CompanyIdAndIsDeletedFalse(project, companyId);
-
-        if (membersToDelete.isEmpty()) {
-            log.info("삭제할 멤버 연결 없음: projectId={}, companyId={}", project.getId(), companyId);
-            return; // 처리할 대상 없으면 종료
-        }
-
+        
         for (MemberProject memberProject: membersToDelete) {
             memberProject.delete();
         }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -130,4 +130,14 @@ public class MemberProjectService {
 
         log.info("멤버 {}명이 프로젝트 ID {} 에서 삭제되었습니다.", membersToDelete.size(), project.getId());
     }
+
+    @Transactional
+    public void deleteSingleMemberFromProject(Project project, Long memberId) {
+        MemberProject memberToDelete = memberProjectRepository.findByProjectAndMemberIdAndIsDeletedFalse(project, memberId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.MEMBER_PROJECT_NOT_FOUND));
+
+        memberToDelete.delete();
+        log.info("단일 멤버 연결 삭제 완료: projectId={}, memberId={}, memberProjectId={}",
+                project.getId(), memberId, memberToDelete.getId());
+    }
 }

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -538,4 +538,28 @@ public class ProjectService {
                 members != null ? members : Collections.emptyList()
         );
     }
+
+    /**
+     * 프로젝트에 참여 중인 회사 삭제 메서드 (회사 삭제되면 해당 회사의 멤버도 자동 삭제)
+     *
+     * @param userRole 요청자의 역할 (ADMIN만 가능)
+     * @param projectId 삭제할 회사가 참여 중인 프로젝트 ID
+     * @param companyId 삭제할 회사 ID
+     * @throws GeneralException ADMIN이 아니거나 유효한 프로젝트가 아닌 경우
+     */
+    @Transactional
+    public void deleteCompanyFromProject(String userRole, Long projectId, Long companyId) {
+        // 프로젝트 유효성 확인
+        Project project = getValidProject(projectId);
+
+        // ADMIN인지 유효성 검사
+        validateAdminRole(userRole);
+
+        // CompanyProject, MemberProject 삭제
+        companyProjectService.deleteCompanyFromProject(project, companyId);
+        log.info("프로젝트에서 회사 연결 삭제 완료: projectId={}, companyId={}", projectId, companyId);
+
+        memberProjectService.deleteMembersFromProject(project, companyId);
+        log.info("프로젝트에서 회사 소속 멤버 삭제 완료: projectId={}, companyId={}", projectId, companyId);
+    }
 }

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -496,34 +497,49 @@ public class ProjectService {
         // 요청 정보 추출
         Company company = companyService.getCompany(request.getCompanyId());
         CompanyProjectRole companyRole = request.getRole();
-        List<Member> managers = memberService.findByIds(request.getManagerIds());
-        List<Member> members = memberService.findByIds(request.getMemberIds());
+        List<Long> managerIds = request.getManagerIds();
+        List<Long> memberIds = request.getMemberIds() != null ? request.getMemberIds() : Collections.emptyList();
+
+        // 멤버들이 회사 소속인지 검증
+        List<Member> managers = memberService.findByIds(managerIds);
+        List<Member> members = memberService.findByIds(memberIds);
+        validateMembersBelongToCompany(managers, company);
+        validateMembersBelongToCompany(members, company);
 
         // 회사 할당
         companyProjectService.assignCompanyToProject(company, project, companyRole);
+        log.info("회사-프로젝트 연결 완료: projectId={}, companyId={}, role={}", projectId, company.getId(), companyRole);
 
         // 역할 할당
-        assignMembersToProject(company, project, companyRole, managers, members);
+        MemberProjectRole targetManagerRole = determineTargetManagerRole(companyRole);
+        MemberProjectRole targetMemberRole = determineTargetMemberRole(companyRole);
+        log.debug("자동 결정된 멤버 역할: managerRole={}, memberRole={}", targetManagerRole, targetMemberRole);
+
+        memberProjectService.assignMembersToProject(company, managers, project, targetManagerRole);
+        log.info("담당자 {}명 프로젝트 연결 완료", managers.size());
+        if (!members.isEmpty()) {
+            memberProjectService.assignMembersToProject(company, members, project, targetMemberRole);
+            log.info("참여자 {}명 프로젝트 연결 완료", members.size());
+        }
 
         log.info("프로젝트에 회사 및 멤버 추가 완료: projectId={}, companyId={}, companyRole={}, managerCount={}, memberCount={}",
-                projectId, company.getId(), companyRole, managers.size(), members != null ? members.size() : 0);
+                projectId, company.getId(), companyRole, managers.size(), members.size());
 
         // response 생성
         return buildResponse(project, company, companyRole, managers, members);
     }
 
-    private void assignMembersToProject(Company company, Project project, CompanyProjectRole companyRole,
-                                        List<Member> managers, List<Member> members) {
-        // 역할 할당
-        MemberProjectRole managerRole = companyRole.getManagerRole();
-        MemberProjectRole memberRole = companyRole.getMemberRole();
-
-        // 매니저 할당
-        memberProjectService.assignMembersToProject(company, managers, project, managerRole);
-
-        // 일반 참여자 할당 (null 체크 필요)
-        if (members != null && !members.isEmpty()) {
-            memberProjectService.assignMembersToProject(company, members, project, memberRole);
+    private void validateMembersBelongToCompany(List<Member> members, Company company) {
+        if (CollectionUtils.isEmpty(members)) {
+            return;
+        }
+        Long expectedCompanyId = company.getId();
+        for (Member member : members) {
+            if (member.getCompany() == null || !member.getCompany().getId().equals(expectedCompanyId)) {
+                log.error("멤버가 예상된 회사({}) 소속이 아닙니다: memberId={}, memberCompany={}",
+                        company.getName(), member.getId(), (member.getCompany() != null ? member.getCompany().getName() : "없음"));
+                throw new GeneralException(ProjectErrorCode.MEMBER_NOT_IN_SPECIFIED_COMPANY);
+            }
         }
     }
 
@@ -561,5 +577,79 @@ public class ProjectService {
 
         memberProjectService.deleteMembersFromProject(project, companyId);
         log.info("프로젝트에서 회사 소속 멤버 삭제 완료: projectId={}, companyId={}", projectId, companyId);
+    }
+
+    @Transactional
+    public ProjectMemberAddResponse addMemberToProject(String userRole, Long projectId, ProjectMemberAddRequest request) {
+        // 요청 유효성 검사 (추가할 멤버가 있는가)
+        List<Long> managerIds = request.getManagerIds() != null ? request.getManagerIds() : Collections.emptyList();
+        List<Long> memberIds = request.getMemberIds() != null ? request.getMemberIds() : Collections.emptyList();
+
+        if (CollectionUtils.isEmpty(managerIds) && CollectionUtils.isEmpty(memberIds)) {
+            log.error("추가할 담당자 또는 일반 참여자 ID 목록이 비어 있습니다.");
+            throw new GeneralException(ProjectErrorCode.MEMBER_LIST_EMPTY); // 에러 코드 정의 필요
+        }
+
+        // 프로젝트 유효성 검사
+        Project project = getValidProject(projectId);
+
+        // ADMIN인지 유효성 검사
+        validateAdminRole(userRole);
+
+        // 회사 유효성 검사 및 프로젝트 참여 확인
+        Company company = companyService.getCompany(request.getCompanyId());
+        CompanyProjectRole companyRole = companyProjectService.getCompanyRoleInProject(company, project);
+
+        if (companyRole == null) {
+            log.error("회사가 프로젝트에 참여하고 있지 않습니다: projectId={}, companyId={}", projectId, request.getCompanyId());
+            throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
+        }
+
+        // 멤버 역할 할당
+        MemberProjectRole targetManagerRole = determineTargetManagerRole(companyRole);
+        MemberProjectRole targetMemberRole = determineTargetMemberRole(companyRole);
+
+        List<Member> managers = managerIds.isEmpty() ? Collections.emptyList() : memberService.findByIds(managerIds);
+        List<Member> members = memberIds.isEmpty() ? Collections.emptyList() : memberService.findByIds(memberIds);
+
+        memberProjectService.assignMembersToProject(company, managers, project, targetManagerRole);
+        memberProjectService.assignMembersToProject(company, members, project, targetMemberRole);
+
+        log.info("프로젝트에 멤버 추가/업데이트 완료: projectId={}, companyId={}, managers={}, members={}",
+                projectId, request.getCompanyId(), managers.size(), members.size());
+
+        List<Member> addedManagers = memberProjectService.getMembersByRole(project, targetManagerRole);
+        List<Member> addedMembers = memberProjectService.getMembersByRole(project, targetMemberRole);
+
+        // response 생성
+        return ProjectMemberAddResponse.from(
+                project.getId(),
+                company.getName(),
+                addedManagers,
+                addedMembers
+        );
+
+    }
+
+    private MemberProjectRole determineTargetMemberRole(CompanyProjectRole companyRole) {
+        if (companyRole == CompanyProjectRole.DEV_COMPANY) {
+            return MemberProjectRole.DEV_PARTICIPANT;
+        } else if (companyRole == CompanyProjectRole.CLIENT_COMPANY) {
+            return MemberProjectRole.CLI_PARTICIPANT;
+        } else {
+            log.error("멤버 역할을 결정할 수 없는 회사 역할입니다: {}", companyRole);
+            throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
+        }
+    }
+
+    private MemberProjectRole determineTargetManagerRole(CompanyProjectRole companyRole) {
+        if (companyRole == CompanyProjectRole.DEV_COMPANY) {
+            return MemberProjectRole.DEV_MANAGER;
+        } else if (companyRole == CompanyProjectRole.CLIENT_COMPANY) {
+            return MemberProjectRole.CLI_MANAGER;
+        } else {
+            log.error("매니저 역할을 결정할 수 없는 회사 역할입니다: {}", companyRole);
+            throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -652,4 +652,16 @@ public class ProjectService {
             throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
         }
     }
+
+    @Transactional
+    public void deleteMemberFromProject(String userRole, Long projectId, Long memberId) {
+        // 프로젝트 유효성 검사
+        Project project = getValidProject(projectId);
+
+        // ADMIN인지 유효성 검사
+        validateAdminRole(userRole);
+
+        memberProjectService.deleteSingleMemberFromProject(project, memberId);
+        log.info("프로젝트에서 단일 멤버 제거 완료: projectId={}, memberId={}", projectId, memberId);
+    }
 }


### PR DESCRIPTION

# 요약
프로젝트 참여 회사/멤버 관리 기능 구현
1. 회사 추가 : 회사 추가 시 멤버도 함께 추가
2. 개별 회사 삭제 : 프로젝트 삭제와 다름 / 회사 삭제 시 해당 회사의 멤버들도 함께 삭제
3. 멤버 추가 : 기존에 프로젝트 참여하는 회사의 다른 멤버들 추가
4. 멤버 삭제 : 기존에 프로젝트 참여하는 멤버 1명 삭제

# 연관 이슈
Closed #138 


# 확인 사항
### 1. `CompanyProjectRole` 원래대로 책임 분리
- 지난 PR 리뷰를 받고, memberProjectRole이 같이 있는 건 책임 분리가 안되는 거 같아 기존의 enum 파일로 다시 구현하였습니다.
- 변경된 코드 로직
```
private MemberProjectRole determineTargetMemberRole(CompanyProjectRole companyRole) {
        if (companyRole == CompanyProjectRole.DEV_COMPANY) {
            return MemberProjectRole.DEV_PARTICIPANT;
        } else if (companyRole == CompanyProjectRole.CLIENT_COMPANY) {
            return MemberProjectRole.CLI_PARTICIPANT;
        } else {
            log.error("멤버 역할을 결정할 수 없는 회사 역할입니다: {}", companyRole);
            throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
        }
    }

    private MemberProjectRole determineTargetManagerRole(CompanyProjectRole companyRole) {
        if (companyRole == CompanyProjectRole.DEV_COMPANY) {
            return MemberProjectRole.DEV_MANAGER;
        } else if (companyRole == CompanyProjectRole.CLIENT_COMPANY) {
            return MemberProjectRole.CLI_MANAGER;
        } else {
            log.error("매니저 역할을 결정할 수 없는 회사 역할입니다: {}", companyRole);
            throw new GeneralException(ProjectErrorCode.COMPANY_PROJECT_NOT_FOUND);
        }
    }
```
- 위 로직을 보면, 각각 담당자, 일반 참여자인 경우 role을 정하는 private method를 생성하였습니다.
- 추후 리팩토링 때 수정될 수 있습니다.
### 2. 프로젝트 회사/멤버 수정 로직 변경
- [이전 PR](https://github.com/Kernel360/KDEV4-SODA-BE/pull/147)에 보면 프로젝트 기본 정보 수정 API를 구현했습니다.
- 관리자는 만약 회사를 추가하거나 멤버를 추가하고 싶은 경우 개별로 추가할 수 있습니다.
- 삭제도 마찬가지입니다.
- 기본 정보와, 회사/멤버 관리를 분리하여 화면에서도 사용자 친화적으로 관리할 수 있도록 구현하였습니다.