### PR TITLE
[Fix] 프로젝트 생성 시 초기 스테이지 생성 수정

### DIFF
--- a/src/main/java/com/soda/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectCreateRequest.java
@@ -28,6 +28,9 @@ public class ProjectCreateRequest {
     @NotNull(message = "종료일은 필수입니다.")
     private LocalDateTime endDate;
 
+    @NotNull
+    private List<String> stageNames;
+
     // 고객사 지정 (프로젝트 생성 시 계약 단계이므로 고객사만 지정)
     @NotNull(message = "고객사 선택은 필수입니다.")
     private List<Long> clientCompanyIds;

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -40,6 +40,7 @@ public class ProjectService {
     private final CompanyService companyService;
     private final CompanyProjectService companyProjectService;
     private final MemberProjectService memberProjectService;
+    private final StageService stageService;
 
     /**
      * 프로젝트를 생성하는 메서드입니다.
@@ -64,7 +65,8 @@ public class ProjectService {
         // 고객사 지정
         assignClientCompanies(request, project);
 
-        // TODO stage 수정 로직 추가 예정
+        // 초기 stage 생성
+        stageService.createInitialStages(project, request.getStageNames());
 
         log.info("프로젝트 생성 완료: 프로젝트 ID = {}", project.getId());
 


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
프로젝트 생성 시 사용자가 직접 초기 스테이지(단계) 목록을 생성할 수 있는 기능을 추가했습니다.

기존에는 스테이지가 고정된 목록으로 생성되고 나중에 수정을 해야 했지만, 
이제 프로젝트 생성 요청 시 stageNames 필드를 통해 원하는 초기 스테이지 이름 목록으로 스테이지를 생성할 수 있습니다.

## 주요 변경 사항
1.  ProjectCreateRequest: List<String> stageNames 필드 추가 (사용자가 정의한 초기 스테이지 이름 목록)
2.  ProjectService: createProject 메소드 내에서 stageService.createInitialStages(project, request.getStageNames()) 호출 로직 추가
3.  StageService:
    *   createInitialStages 메소드 시그니처 변경 (Long projectId -> Project project, List<String> stageNames)
    *   고정된 INITIAL_STAGE_NAMES 사용 로직 제거
    *   전달받은 stageNames 목록 기반으로 스테이지 생성 로직 구현

# 연관 이슈
Close #149

# Pull Request 체크리스트

## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?


