### PR TITLE
[Fix] 프로젝트 생성/개발사 추가 시, 회사와 멤버를 중복 추가 시 생기는 오류 해결

### DIFF
--- a/src/main/java/com/soda/project/dto/CompanyAssignment.java
+++ b/src/main/java/com/soda/project/dto/CompanyAssignment.java
@@ -1,0 +1,24 @@
+package com.soda.project.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CompanyAssignment {
+
+    @NotNull(message = "회사 ID는 필수입니다.")
+    private Long companyId;
+
+    // 담당자 목록은 필수
+    @NotEmpty(message = "담당자 ID 목록은 필수입니다.")
+    private List<Long> managerIds;
+
+    // 일반 참여자 목록은 선택 사항
+    private List<Long> memberIds;
+
+}

--- a/src/main/java/com/soda/project/dto/DevCompanyAssignmentRequest.java
+++ b/src/main/java/com/soda/project/dto/DevCompanyAssignmentRequest.java
@@ -1,5 +1,6 @@
 package com.soda.project.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,12 +11,8 @@ import java.util.List;
 @Builder
 public class DevCompanyAssignmentRequest {
 
-    @NotNull(message = "개발사 선택은 필수입니다.")
-    private List<Long> devCompanyIds;
-
-    @NotNull(message = "개발사 담당자 선택은 필수입니다.")
-    private List<Long> devMangerIds;
-
-    private List<Long> devMemberIds;
+    @NotNull
+    @Valid
+    private List<CompanyAssignment> devAssignments;
 
 }

--- a/src/main/java/com/soda/project/dto/DevCompanyAssignmentResponse.java
+++ b/src/main/java/com/soda/project/dto/DevCompanyAssignmentResponse.java
@@ -2,32 +2,56 @@ package com.soda.project.dto;
 
 import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberProjectRole;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class DevCompanyAssignmentResponse {
 
-    private List<String> devCompanies;
-    private List<String> devManagers;
-    private List<String> devMembers;
+    // 개발사별 할당 정보 리스트 (CompanyAssignment 직접 사용)
+    private List<CompanyAssignment> devAssignments;
 
-    public static DevCompanyAssignmentResponse from (List<Company> devCompanies,
-                                                     List<Member> devManagers, List<Member> devMembers) {
+    public static DevCompanyAssignmentResponse from(
+            Map<Company, Map<MemberProjectRole, List<Member>>> devAssignmentData) {
+
+        // Map 데이터를 List<CompanyAssignment>로 변환
+        List<CompanyAssignment> assignments = devAssignmentData.entrySet().stream()
+                .map(entry -> {
+                    Company company = entry.getKey();
+                    Map<MemberProjectRole, List<Member>> roleToMembersMap = entry.getValue();
+
+                    // 역할별 멤버 id 추출
+                    List<Long> managerIds = extractMemberIds(roleToMembersMap.get(MemberProjectRole.DEV_MANAGER));
+                    List<Long> memberIds = extractMemberIds(roleToMembersMap.get(MemberProjectRole.DEV_PARTICIPANT));
+
+                    // CompanyAssignment 생성
+                    return CompanyAssignment.builder()
+                            .companyId(company.getId())
+                            .managerIds(managerIds)
+                            .memberIds(memberIds)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // 최종 응답 DTO 빌드
         return DevCompanyAssignmentResponse.builder()
-                .devCompanies(devCompanies.stream()
-                        .map(Company::getName)
-                        .collect(Collectors.toList()))
-                .devManagers(devManagers.stream()
-                        .map(Member::getName)
-                        .collect(Collectors.toList()))
-                .devMembers(devMembers.stream()
-                        .map(Member::getName)
-                        .collect(Collectors.toList()))
+                .devAssignments(assignments)
                 .build();
+    }
+
+    // 멤버 ID 추출 헬퍼 메서드
+    private static List<Long> extractMemberIds(List<Member> members) {
+        if (members == null || members.isEmpty()) {
+            return List.of();
+        }
+        return members.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/soda/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/soda/project/dto/ProjectCreateRequest.java
@@ -1,6 +1,7 @@
 package com.soda.project.dto;
 
 import com.soda.project.enums.ProjectStatus;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -32,12 +33,8 @@ public class ProjectCreateRequest {
     private List<String> stageNames;
 
     // 고객사 지정 (프로젝트 생성 시 계약 단계이므로 고객사만 지정)
-    @NotNull(message = "고객사 선택은 필수입니다.")
-    private List<Long> clientCompanyIds;
-
-    @NotNull(message = "고객사 담당자 선택은 필수입니다.")
-    private List<Long> clientMangerIds;
-
-    private List<Long> clientMemberIds;
+    @NotNull
+    @Valid
+    private List<CompanyAssignment> clientAssignments;
 
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -1,5 +1,6 @@
 package com.soda.project.repository;
 
+import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.MemberProjectRole;
 import com.soda.project.entity.MemberProject;
@@ -21,12 +22,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
 
     List<MemberProject> findByProjectAndRoleAndIsDeletedFalse(Project project, MemberProjectRole role);
 
-    List<MemberProject> findByProjectAndRole(Project project, MemberProjectRole role);
-
-    MemberProject findByMemberAndProjectAndRole(Member member, Project project, MemberProjectRole role);
-
-    List<Project> findByMemberIdAndIsDeletedFalse(Long memberId);
-
     Optional<MemberProject> findByMemberAndProject(Member member, Project project);
 
     Page<MemberProject> findByMemberId(Long userId, Pageable pageable);
@@ -36,4 +31,9 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     List<MemberProject> findAllByProjectAndMember_CompanyIdAndIsDeletedFalse(Project project, Long companyId);
 
     Optional<MemberProject> findByProjectAndMemberIdAndIsDeletedFalse(Project project, Long memberId);
-}
+
+    List<MemberProject> findAllByProjectAndMember_CompanyAndRoleAndIsDeletedFalse(
+            Project project,
+            Company company,
+            MemberProjectRole role
+    );}


### PR DESCRIPTION

# 요약
프로젝트 생성할때 / 개발사 추가할 때,
 각 회사를 순회할 때마다 모든 매니저와 모든 일반 멤버가 해당 회사 소속으로 프로젝트에 중복 할당되는 오류 해결


# 연관 이슈
Closed #151 


# 확인사항
### 1. 오류 발생 확인
- 기존 로직에서, 회사를 다중 선택할 시 오류가 생겼었습니다.
- 각 회사를 순회할 때마다 모든 매니저와 모든 일반 멤버가 해당 회사 소속으로 프로젝트에 중복 할당되는 문제였습니다.
- 따라서 응답받는 DTO 형식을 변경하고, 서비스 로직을 수정하였습니다.
### 2. `CompanyAssignment` DTO 생성
- 각 회사별로 해당 회사의 매니저 ID 리스트와 멤버 ID 리스트를 묶어서 전달하기 위해 공통 DTO를 생성하였습니다.
```
@Getter
@Builder
public class CompanyAssignment {

    @NotNull(message = "회사 ID는 필수입니다.")
    private Long companyId;

    // 담당자 목록은 필수
    @NotEmpty(message = "담당자 ID 목록은 필수입니다.")
    private List<Long> managerIds;

    // 일반 참여자 목록은 선택 사항
    private List<Long> memberIds;

}
```
### 3. 서비스 로직 수정
- DTO가 변경됨에 따라 request, respons 도 수정하였습니다.
- 또한 서비스 로직도 수정하였습니다.