### PR TITLE
[Refactor] 프로젝트에 속한 멤버들 조회 기능 query 부분 리팩토링

### DIFF
--- a/src/main/java/com/soda/global/config/QueryDslConfig.java
+++ b/src/main/java/com/soda/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.soda.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -122,14 +122,10 @@ public class ProjectController {
     @GetMapping("/{projectId}/members")
     public ResponseEntity<ApiResponseForm<Page<ProjectMemberResponse>>> getProjectMembers(
             @PathVariable Long projectId,
-            @RequestParam(required = false) CompanyProjectRole companyRole,
-            @RequestParam(required = false) Long companyId,
-            @RequestParam(required = false) MemberProjectRole memberRole,
+            @ModelAttribute ProjectMemberSearchCondition searchCondition,
             @PageableDefault(sort = "member.name", direction = Sort.Direction.ASC) Pageable pageable
     ) {
-        Page<ProjectMemberResponse> memberPage = projectService.getProjectMembers(
-                projectId, companyRole, companyId, memberRole, pageable
-        );
+        Page<ProjectMemberResponse> memberPage = projectService.getProjectMembers(projectId, searchCondition, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(memberPage));
     }
 }

--- a/src/main/java/com/soda/project/dto/ProjectMemberSearchCondition.java
+++ b/src/main/java/com/soda/project/dto/ProjectMemberSearchCondition.java
@@ -1,0 +1,18 @@
+package com.soda.project.dto;
+
+import com.soda.member.enums.CompanyProjectRole;
+import com.soda.member.enums.MemberProjectRole;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectMemberSearchCondition {
+
+    private CompanyProjectRole companyRole;
+    private Long companyId;
+    private MemberProjectRole memberRole;
+
+}

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface MemberProjectRepository extends JpaRepository<MemberProject, Long> {
+public interface MemberProjectRepository extends JpaRepository<MemberProject, Long>, MemberProjectRepositoryCustom {
 
     List<MemberProject> findByProject(Project project);
 
@@ -37,22 +37,5 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
             Company company,
             MemberProjectRole role
     );
-
-    @Query(value = "SELECT mp FROM MemberProject mp JOIN FETCH mp.member m JOIN FETCH m.company c " +
-            "WHERE mp.project.id = :projectId AND mp.isDeleted = false " +
-            "AND (:companyIds IS NULL OR c.id IN :companyIds) " +
-            "AND (:companyId IS NULL OR c.id = :companyId) " +
-            "AND (:memberRole IS NULL OR mp.role = :memberRole)",
-            countQuery = "SELECT COUNT(mp) FROM MemberProject mp JOIN mp.member m JOIN m.company c " +
-                    "WHERE mp.project.id = :projectId AND mp.isDeleted = false " +
-                    "AND (:companyIds IS NULL OR c.id IN :companyIds) " +
-                    "AND (:companyId IS NULL OR c.id = :companyId) " +
-                    "AND (:memberRole IS NULL OR mp.role = :memberRole)")
-    Page<MemberProject> findFilteredMembersAndIsDeletedFalse(
-                                                              @Param("projectId") Long projectId,
-                                                              @Param("companyIds") List<Long> companyIds,
-                                                              @Param("companyId") Long companyId,
-                                                              @Param("memberRole") MemberProjectRole memberRole,
-                                                              Pageable pageable);
 
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.soda.project.repository;
+
+import com.soda.member.enums.MemberProjectRole;
+import com.soda.project.entity.MemberProject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MemberProjectRepositoryCustom {
+
+    Page<MemberProject> findFilteredMembers(Long projectId,
+                                            List<Long> companyIds,
+                                            Long companyId,
+                                            MemberProjectRole memberRole,
+                                            Pageable pageable);
+}

--- a/src/main/java/com/soda/project/repository/MemberProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepositoryImpl.java
@@ -1,0 +1,134 @@
+package com.soda.project.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soda.member.enums.MemberProjectRole;
+import com.soda.project.entity.MemberProject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+
+import static com.soda.project.entity.QMemberProject.memberProject;
+import static com.soda.member.entity.QMember.member;
+import static com.soda.member.entity.QCompany.company;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberProjectRepositoryImpl implements MemberProjectRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MemberProject> findFilteredMembers(Long projectId,
+                                                   List<Long> companyIds,
+                                                   Long companyId,
+                                                   MemberProjectRole memberRole,
+                                                   Pageable pageable) {
+
+        // 1. 데이터 조회 쿼리 (fetch join 사용)
+        JPAQuery<MemberProject> dataQuery = queryFactory
+                .selectFrom(memberProject)
+                .join(memberProject.member, member).fetchJoin()
+                .join(member.company, company).fetchJoin()
+                .where(
+                        memberProject.project.id.eq(projectId),
+                        memberProject.isDeleted.isFalse(),
+                        companyIdsIn(companyIds),
+                        companyIdEq(companyId),
+                        memberRoleEq(memberRole)
+                )
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<MemberProject> content = dataQuery.fetch();
+
+        // 2. Count 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(memberProject.count())
+                .from(memberProject)
+                .join(memberProject.member, member)
+                .join(member.company, company)
+                .where(
+                        memberProject.project.id.eq(projectId),
+                        memberProject.isDeleted.isFalse(),
+                        companyIdsIn(companyIds),
+                        companyIdEq(companyId),
+                        memberRoleEq(memberRole)
+                );
+
+        // 3. Page 객체 생성 및 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 회사 ID 목록(companyIds) 조건을 생성합니다. 목록이 비어있으면 null을 반환합니다.
+     */
+    private BooleanExpression companyIdsIn(List<Long> companyIds) {
+        return CollectionUtils.isEmpty(companyIds) ? null : company.id.in(companyIds);
+    }
+
+    /**
+     * 개별 회사 ID(companyId) 조건을 생성합니다. ID가 null이면 null을 반환합니다.
+     */
+    private BooleanExpression companyIdEq(Long companyId) {
+        return ObjectUtils.isEmpty(companyId) ? null : company.id.eq(companyId);
+    }
+
+    /**
+     * 멤버 역할(memberRole) 조건을 생성합니다. 역할이 null이면 null을 반환
+     */
+    private BooleanExpression memberRoleEq(MemberProjectRole memberRole) {
+        return ObjectUtils.isEmpty(memberRole) ? null : memberProject.role.eq(memberRole);
+    }
+
+    /**
+     * Spring Data의 Sort 객체를 QueryDSL의 OrderSpecifier 배열로 변환합니다.
+     * @param sort Pageable에서 추출한 Sort 객체
+     * @return QueryDSL의 orderBy 절에 사용할 OrderSpecifier 배열
+     */
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return new OrderSpecifier[]{new OrderSpecifier<>(Order.ASC, member.name)};
+        }
+
+        // PathBuilder를 사용하여 문자열 기반 속성 경로를 QueryDSL Path 객체로 변환
+        PathBuilder<MemberProject> entityPath = new PathBuilder<>(MemberProject.class, "memberProject");
+
+        return sort.stream()
+                .map(order -> {
+                    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+                    String property = order.getProperty();
+
+                    PathBuilder<?> path = resolvePath(entityPath, property);
+
+                    return new OrderSpecifier(direction, path);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    /**
+     * 점(.)으로 구분된 속성 문자열(예: "member.name")을 기반으로 실제 PathBuilder 경로를 찾습니다.
+     * @param rootPath 시작 PathBuilder (엔티티 루트)
+     * @param property 속성 문자열
+     * @return 해당 속성에 대한 PathBuilder
+     */
+    private PathBuilder<?> resolvePath(PathBuilder<?> rootPath, String property) {
+        PathBuilder<?> currentPath = rootPath;
+        String[] parts = property.split("\\.");
+        for (String part : parts) {
+            currentPath = currentPath.get(part, Comparable.class);
+        }
+        return currentPath;
+    }
+}

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -143,7 +143,7 @@ public class MemberProjectService {
                 projectId, filteredCompanyIds, specificCompanyId, memberRole);
 
         // 수정된 Repository 메서드 호출
-        return memberProjectRepository.findFilteredMembersAndIsDeletedFalse( // 변경된 메서드 이름 사용
+        return memberProjectRepository.findFilteredMembers(
                 projectId,
                 filteredCompanyIds,
                 specificCompanyId,


### PR DESCRIPTION

# 요약
프로젝트에 속한 멤버들 조회 기능 query 부분 리팩토링

# 연관 이슈
Closed #155 

# 확인사항
### 1. global > config 에 `QueryDslConfig` 생성
- QueryDSL 쿼리를 작성하고 실행하는 데 필요한 핵심 도구인 JPAQueryFactory 객체를 만들어서 스프링(Spring)이 관리하는 빈(Bean)으로 등록하기 위해서 생성하였습니다.
### 2. custom repository 생성
- 기존 쿼리문이 너무 복잡하고 길어서 안정성이 떨어졌습니다.
- 그래서 코드 리뷰도 받은 겸, 작업 중인 리팩토링을 완료하여 해당 쿼리문을 삭제하였습니다.
- custom repository를 생성하여 복잡한 동적 쿼리를 구현하였습니다.
### 3. `@ModelAttribute` 적용
- 기존 request param을 하나로 모아 `ProjectMemberSearchCondition`라는 새로운 DTO를 만들었습니다.