### PR TITLE
[Refactor] 현재 프로젝트에 속한 멤버 조회할 때 memberId를 기반으로 조회할 수 있게 수정

### DIFF
--- a/src/main/java/com/soda/project/dto/ProjectMemberSearchCondition.java
+++ b/src/main/java/com/soda/project/dto/ProjectMemberSearchCondition.java
@@ -14,5 +14,6 @@ public class ProjectMemberSearchCondition {
     private CompanyProjectRole companyRole;
     private Long companyId;
     private MemberProjectRole memberRole;
+    private Long memberId;
 
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepositoryCustom.java
@@ -13,5 +13,6 @@ public interface MemberProjectRepositoryCustom {
                                             List<Long> companyIds,
                                             Long companyId,
                                             MemberProjectRole memberRole,
+                                            Long memberId,
                                             Pageable pageable);
 }

--- a/src/main/java/com/soda/project/repository/MemberProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepositoryImpl.java
@@ -17,11 +17,11 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
-import static com.soda.project.entity.QMemberProject.memberProject;
-import static com.soda.member.entity.QMember.member;
-import static com.soda.member.entity.QCompany.company;
-
 import java.util.List;
+
+import static com.soda.member.entity.QCompany.company;
+import static com.soda.member.entity.QMember.member;
+import static com.soda.project.entity.QMemberProject.memberProject;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,6 +33,7 @@ public class MemberProjectRepositoryImpl implements MemberProjectRepositoryCusto
                                                    List<Long> companyIds,
                                                    Long companyId,
                                                    MemberProjectRole memberRole,
+                                                   Long memberId,
                                                    Pageable pageable) {
 
         // 1. 데이터 조회 쿼리 (fetch join 사용)
@@ -45,7 +46,8 @@ public class MemberProjectRepositoryImpl implements MemberProjectRepositoryCusto
                         memberProject.isDeleted.isFalse(),
                         companyIdsIn(companyIds),
                         companyIdEq(companyId),
-                        memberRoleEq(memberRole)
+                        memberRoleEq(memberRole),
+                        memberIdEq(memberId)
                 )
                 .orderBy(getOrderSpecifiers(pageable.getSort()))
                 .offset(pageable.getOffset())
@@ -64,11 +66,16 @@ public class MemberProjectRepositoryImpl implements MemberProjectRepositoryCusto
                         memberProject.isDeleted.isFalse(),
                         companyIdsIn(companyIds),
                         companyIdEq(companyId),
-                        memberRoleEq(memberRole)
+                        memberRoleEq(memberRole),
+                        memberIdEq(memberId)
                 );
 
         // 3. Page 객체 생성 및 반환
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return ObjectUtils.isEmpty(memberId) ? null : member.id.eq(memberId);
     }
 
     /**

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -137,6 +137,7 @@ public class MemberProjectService {
                                                                            List<Long> filteredCompanyIds,
                                                                            Long specificCompanyId,
                                                                            MemberProjectRole memberRole,
+                                                                           Long memberId,
                                                                            Pageable pageable) {
 
         log.debug("삭제되지 않은 MemberProject 필터링 조회 (Repository 호출): projectId={}, filteredCompanyIds={}, specificCompanyId={}, memberRole={}",
@@ -148,6 +149,7 @@ public class MemberProjectService {
                 filteredCompanyIds,
                 specificCompanyId,
                 memberRole,
+                memberId,
                 pageable
         );
     }

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -467,6 +467,7 @@ public class ProjectService {
         // 3. MemberProjectService 호출
         Long companyId = searchCondition.getCompanyId();
         MemberProjectRole memberRole = searchCondition.getMemberRole();
+        Long memberId = searchCondition.getMemberId();
 
         log.debug("MemberProjectService 필터링 조회 시작: projectId={}, filteredCompanyIds={}, companyId={}, memberRole={}",
                 projectId, filteredCompanyIds != null ? filteredCompanyIds : "N/A", companyId, memberRole);
@@ -477,6 +478,7 @@ public class ProjectService {
                 filteredCompanyIds,
                 companyId,
                 memberRole,
+                memberId,
                 pageable
         );
         log.debug("MemberProjectService 조회 완료: {}개의 삭제되지 않은 MemberProject 조회됨 (Total Elements)", memberProjectPage.getTotalElements());


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 현재 프로젝트에 속한 멤버 조회할 때 memberId를 기반으로 조회할 수 있게 수정

# 연관 이슈
#159 

# 확인해야할 사항
- Request를 상세조회할 때 approver의 이름, 프로젝트에서의 Role등을 반환하게 하려했는데 연관관계가 복잡하여 Request를 조회해서 받은 승인권자의 id(memberId)를 바탕으로 GET projects/{projectId}/member?memberId={memberId} 로 보내서 멤버의 이름, 프로젝트에서의 권한을 받는 방식으로 해결하기 위해 GET projects/{projectId}/member API를 수정하였습니다.