### PR TITLE
[Fix] 프로젝트에 회사 추가 시 기존 사용자 권한 수정 안되는 버그 수정

### DIFF
--- a/src/main/java/com/soda/project/entity/MemberProject.java
+++ b/src/main/java/com/soda/project/entity/MemberProject.java
@@ -40,6 +40,12 @@ public class MemberProject extends BaseEntity {
         this.markAsActive();
     }
 
+    public void changeRole(MemberProjectRole newRole) {
+        if (newRole != null) {
+            this.role = newRole;
+        }
+    }
+
     public void updateMemberProject(Member member, Project project, MemberProjectRole memberProjectRole) {
         this.member = member;
         this.project = project;

--- a/src/main/java/com/soda/project/repository/MemberProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/MemberProjectRepository.java
@@ -40,4 +40,6 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
 
     @Query("SELECT mp.project.id FROM MemberProject mp WHERE mp.member.id = :memberId AND mp.isDeleted = false")
     List<Long> findAllProjectIdsByMemberIdAndIsDeletedFalse(@Param("memberId") Long memberId);
+
+    Optional<MemberProject> findByMemberAndProject(Member member, Project project);
 }

--- a/src/main/java/com/soda/project/service/MemberProjectService.java
+++ b/src/main/java/com/soda/project/service/MemberProjectService.java
@@ -29,15 +29,56 @@ public class MemberProjectService {
     private final MemberProjectRepository memberProjectRepository;
 
     public void assignMembersToProject(Company company, List<Member> members, Project project, MemberProjectRole role) {
+        if (CollectionUtils.isEmpty(members)) {
+            log.debug("할당할 멤버 목록이 비어있습니다. projectId={}, companyId={}", project.getId(), company.getId());
+            return; // 처리할 멤버 없으면 종료
+        }
+
+        log.info("멤버 할당 시작: projectId={}, companyId={}, role={}, memberCount={}",
+                project.getId(), company.getId(), role, members.size());
+
         members.forEach(member -> {
-            if (!member.getCompany().getId().equals(company.getId())) {
+            // 1. 멤버가 제공된 회사 소속인지 검증
+            if (member.getCompany() == null || !member.getCompany().getId().equals(company.getId())) {
+                log.error("멤버(id:{})가 지정된 회사(id:{}) 소속이 아닙니다.", member.getId(), company.getId());
                 throw new GeneralException(ProjectErrorCode.INVALID_MEMBER_COMPANY);
             }
 
-            if (!existsByMemberAndProjectAndIsDeletedFalse(member, project)) {
+            // 2. 해당 멤버와 프로젝트에 대한 MemberProject 조회
+            Optional<MemberProject> existingEntryOpt = memberProjectRepository.findByMemberAndProject(member, project);
+
+            if (existingEntryOpt.isPresent()) {
+                // 3. 기존 레코드가 존재할 경우
+                MemberProject existingEntry = existingEntryOpt.get();
+
+                if (existingEntry.getIsDeleted()) {
+                    // 3-1. 삭제된 상태였으면 활성화하고 역할 업데이트
+                    log.info("기존 삭제된 멤버-프로젝트 연결 활성화 및 역할 업데이트: memberId={}, projectId={}, newRole={}",
+                            member.getId(), project.getId(), role);
+                    existingEntry.reActive();
+                    existingEntry.changeRole(role);
+                    memberProjectRepository.save(existingEntry);
+                } else {
+                    // 3-2. 이미 활성 상태면 역할 비교 후 업데이트
+                    if (!existingEntry.getRole().equals(role)) {
+                        log.info("기존 활성 멤버-프로젝트 연결 역할 변경: memberId={}, projectId={}, oldRole={}, newRole={}",
+                                member.getId(), project.getId(), existingEntry.getRole(), role);
+                        existingEntry.changeRole(role); // 역할 변경
+                        memberProjectRepository.save(existingEntry); // 변경사항 저장
+                    } else {
+                        log.debug("멤버(id:{})는 이미 프로젝트(id:{})에 동일한 역할({})로 활성 상태입니다. 변경 없음.",
+                                member.getId(), project.getId(), role);
+                        // 역할이 동일하면 아무 작업도 하지 않음
+                    }
+                }
+            } else {
+                // 4. 기존 정보가 존재하지 않으면 새로 생성
+                log.info("신규 멤버-프로젝트 연결 생성: memberId={}, projectId={}, role={}",
+                        member.getId(), project.getId(), role);
                 createAndSaveMemberProject(member, project, role);
             }
         });
+        log.info("멤버 할당 완료: projectId={}, companyId={}", project.getId(), company.getId());
     }
 
     private void createAndSaveMemberProject(Member member, Project project, MemberProjectRole role) {


### PR DESCRIPTION

# 요약
프로젝트에 회사 추가 시 기존 사용자 권한 수정 안되는 버그 수정

# 연관 이슈
closed #160 


# 확인사항
- `MemberProject` entity에 `chageRole` 추가했습니다. (role을 수정하기 위한 메서드)
- 기존 멤버가 존재하는 경우 역할이 다르면 -> 해당 멤버의 권한 바꾸기
- 기존 멤버가 존재하는 경우 역할이 같으면-> 아무것도 변경하지 않음
- 기존 멤버가 없으면 -> 새로운 멤버 추가
- 위와 같은 경우의 수를 생각하도록 로직을 수정하였습니다.