### PR TITLE
[Fix] 승인권자가 여러명일 때 한 명이 승인하거나 거절했을 때 승인요청의 상태가 변경되는 버그 수정

### DIFF
--- a/src/main/java/com/soda/request/dto/response/RequestApproveResponse.java
+++ b/src/main/java/com/soda/request/dto/response/RequestApproveResponse.java
@@ -2,7 +2,7 @@ package com.soda.request.dto.response;
 
 import com.soda.common.link.dto.LinkDTO;
 import com.soda.request.entity.Response;
-import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +17,7 @@ public class RequestApproveResponse {
     private Long requestId;
     private Long memberId;
     private String memberName;
-    private RequestStatus status;
+    private ResponseStatus status;
     private String comment;
     private List<LinkDTO> links;
     private LocalDateTime createdAt;
@@ -29,7 +29,7 @@ public class RequestApproveResponse {
                 .requestId(response.getRequest().getId())
                 .memberId(response.getMember().getId())
                 .memberName(response.getMember().getName())
-                .status(response.getRequest().getStatus())
+                .status(response.getStatus())
                 .comment(response.getComment())
                 .links(
                         response.getLinks().stream()

--- a/src/main/java/com/soda/request/dto/response/RequestRejectResponse.java
+++ b/src/main/java/com/soda/request/dto/response/RequestRejectResponse.java
@@ -2,7 +2,7 @@ package com.soda.request.dto.response;
 
 import com.soda.common.link.dto.LinkDTO;
 import com.soda.request.entity.Response;
-import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +17,7 @@ public class RequestRejectResponse {
     private Long requestId;
     private Long memberId;
     private String memberName;
-    private RequestStatus status;
+    private ResponseStatus status;
     private String comment;
     private List<LinkDTO> links;
     private LocalDateTime createdAt;
@@ -29,7 +29,7 @@ public class RequestRejectResponse {
                 .requestId(response.getRequest().getId())
                 .memberId(response.getMember().getId())
                 .memberName(response.getMember().getName())
-                .status(response.getRequest().getStatus())
+                .status(response.getStatus())
                 .comment(response.getComment())
                 .links(
                         response.getLinks().stream()

--- a/src/main/java/com/soda/request/dto/response/ResponseDTO.java
+++ b/src/main/java/com/soda/request/dto/response/ResponseDTO.java
@@ -3,7 +3,7 @@ package com.soda.request.dto.response;
 import com.soda.common.file.dto.FileDTO;
 import com.soda.common.link.dto.LinkDTO;
 import com.soda.request.entity.Response;
-import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -21,7 +21,7 @@ public class ResponseDTO {
     private String comment;
     private List<LinkDTO> links;
     private List<FileDTO> files;
-    private RequestStatus status;
+    private ResponseStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -45,7 +45,7 @@ public class ResponseDTO {
                                 .map(FileDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )
-                .status(response.getRequest().getStatus())
+                .status(response.getStatus())
                 .createdAt(response.getCreatedAt())
                 .updatedAt(response.getUpdatedAt())
                 .build();

--- a/src/main/java/com/soda/request/dto/response/ResponseDeleteResponse.java
+++ b/src/main/java/com/soda/request/dto/response/ResponseDeleteResponse.java
@@ -1,8 +1,7 @@
 package com.soda.request.dto.response;
 
-import com.soda.request.entity.Request;
 import com.soda.request.entity.Response;
-import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +15,7 @@ public class ResponseDeleteResponse {
     private Long memberId;
     private String memberName;
     private String comment;
-    private RequestStatus status;
+    private ResponseStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Boolean isDeleted;
@@ -28,7 +27,7 @@ public class ResponseDeleteResponse {
                 .memberId(response.getMember().getId())
                 .memberName(response.getMember().getName())
                 .comment(response.getComment())
-                .status(response.getRequest().getStatus())
+                .status(response.getStatus())
                 .createdAt(response.getCreatedAt())
                 .updatedAt(response.getUpdatedAt())
                 .isDeleted(response.getIsDeleted())

--- a/src/main/java/com/soda/request/dto/response/ResponseUpdateResponse.java
+++ b/src/main/java/com/soda/request/dto/response/ResponseUpdateResponse.java
@@ -2,7 +2,7 @@ package com.soda.request.dto.response;
 
 import com.soda.common.link.dto.LinkDTO;
 import com.soda.request.entity.Response;
-import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,7 +17,7 @@ public class ResponseUpdateResponse {
     private Long requestId;
     private Long memberId;
     private String memberName;
-    private RequestStatus status;
+    private ResponseStatus status;
     private String comment;
     private List<LinkDTO> links;
     private LocalDateTime createdAt;
@@ -30,7 +30,7 @@ public class ResponseUpdateResponse {
                 .requestId(response.getRequest().getId())
                 .memberId(response.getMember().getId())
                 .memberName(response.getMember().getName())
-                .status(response.getRequest().getStatus())
+                .status(response.getStatus())
                 .comment(response.getComment())
                 .links(response.getLinks().stream()
                         .map(LinkDTO::fromEntity)

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -49,6 +49,9 @@ public class Request extends BaseEntity {
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
     private List<ApproverDesignation> approvers;
 
+    @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    private List<Response> responses;
+
     @Builder
     public Request(Member member, Stage stage, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
         this.member = member;

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class Request extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     private RequestStatus status;
 
     @TrackUpdate
@@ -103,5 +104,9 @@ public class Request extends BaseEntity {
             this.approvers = new ArrayList<>();
         }
         this.approvers.addAll(approverDesignations);
+    }
+
+    public void approving() {
+        this.status = RequestStatus.APPROVING;
     }
 }

--- a/src/main/java/com/soda/request/entity/Response.java
+++ b/src/main/java/com/soda/request/entity/Response.java
@@ -2,6 +2,7 @@ package com.soda.request.entity;
 
 import com.soda.common.BaseEntity;
 import com.soda.member.entity.Member;
+import com.soda.request.enums.ResponseStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,6 +19,8 @@ public class Response extends BaseEntity {
 
     private String comment;
 
+    private ResponseStatus status;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "request_id")
     private Request request;
@@ -33,9 +36,10 @@ public class Response extends BaseEntity {
     private List<ResponseLink> links;
 
     @Builder
-    public Response(Member member, String comment, Request request, List<ResponseFile> files, List<ResponseLink> links) {
+    public Response(Member member, String comment, ResponseStatus status, Request request, List<ResponseFile> files, List<ResponseLink> links) {
         this.member = member;
         this.comment = comment;
+        this.status = status;
         this.request = request;
         this.files = files;
         this.links = links;

--- a/src/main/java/com/soda/request/entity/Response.java
+++ b/src/main/java/com/soda/request/entity/Response.java
@@ -19,6 +19,7 @@ public class Response extends BaseEntity {
 
     private String comment;
 
+    @Enumerated(EnumType.STRING)
     private ResponseStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/soda/request/enums/RequestStatus.java
+++ b/src/main/java/com/soda/request/enums/RequestStatus.java
@@ -2,6 +2,7 @@ package com.soda.request.enums;
 
 public enum RequestStatus {
     APPROVED("승인됨"),
+    APPROVING("승인중"),
     PENDING("대기중"),
     REJECTED("거절됨")
     ;

--- a/src/main/java/com/soda/request/enums/ResponseStatus.java
+++ b/src/main/java/com/soda/request/enums/ResponseStatus.java
@@ -1,0 +1,13 @@
+package com.soda.request.enums;
+
+public enum ResponseStatus {
+    APPROVED("승인됨"),
+    REJECTED("거절됨")
+    ;
+
+    private final String description;
+
+    ResponseStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -20,6 +20,7 @@ import com.soda.request.entity.ApproverDesignation;
 import com.soda.request.entity.Request;
 import com.soda.request.entity.RequestLink;
 import com.soda.request.enums.RequestStatus;
+import com.soda.request.enums.ResponseStatus;
 import com.soda.request.error.RequestErrorCode;
 import com.soda.request.repository.ApproverDesignationRepository;
 import com.soda.request.repository.RequestLinkRepository;
@@ -115,7 +116,15 @@ public class RequestService {
 
     @Transactional
     public void approve(Request request) {
-        request.approve();
+        if (isAllApproversApproved(request)) {
+            request.approve();
+        } else {
+            request.approving();
+        }
+    }
+
+    private static boolean isAllApproversApproved(Request request) {
+        return request.getResponses().stream().filter(response -> response.getStatus() == ResponseStatus.APPROVED).count() == request.getApprovers().size();
     }
 
     @Transactional

--- a/src/main/java/com/soda/request/service/ResponseService.java
+++ b/src/main/java/com/soda/request/service/ResponseService.java
@@ -15,6 +15,7 @@ import com.soda.request.entity.ApproverDesignation;
 import com.soda.request.entity.Request;
 import com.soda.request.entity.Response;
 import com.soda.request.entity.ResponseLink;
+import com.soda.request.enums.ResponseStatus;
 import com.soda.request.error.RequestErrorCode;
 import com.soda.request.error.ResponseErrorCode;
 import com.soda.request.repository.ResponseRepository;
@@ -45,7 +46,7 @@ public class ResponseService {
         validateProjectAuthority(member, requestApproveRequest.getProjectId());
         validateApprover(member, request.getApprovers());
 
-        Response approval = createResponse(member, request, requestApproveRequest.getComment(), requestApproveRequest.getLinks());
+        Response approval = createResponse(member, request, requestApproveRequest.getComment(), requestApproveRequest.getLinks(), ResponseStatus.APPROVED);
         responseRepository.save(approval);
 
         requestService.approve(request);
@@ -62,7 +63,7 @@ public class ResponseService {
         validateProjectAuthority(member, requestRejectRequest.getProjectId());
         validateApprover(member, request.getApprovers());
 
-        Response rejection = createResponse(member, request, requestRejectRequest.getComment(), requestRejectRequest.getLinks());
+        Response rejection = createResponse(member, request, requestRejectRequest.getComment(), requestRejectRequest.getLinks(), ResponseStatus.REJECTED);
         responseRepository.save(rejection);
 
         requestService.reject(request);
@@ -130,18 +131,19 @@ public class ResponseService {
 
 
     // 분리한 메서드들
-    private Response createResponse(Member member, Request request, String comment, List<LinkUploadRequest.LinkUploadDTO> linkDTOs) {
-        Response response = buildResponse(member, request, comment);
+    private Response createResponse(Member member, Request request, String comment, List<LinkUploadRequest.LinkUploadDTO> linkDTOs, ResponseStatus responseStatus) {
+        Response response = buildResponse(member, request, comment, responseStatus);
         List<ResponseLink> links = linkService.buildLinks("response", response, linkDTOs);
         response.addLinks(links);
         return response;
     }
 
-    private Response buildResponse(Member member, Request request, String comment) {
+    private Response buildResponse(Member member, Request request, String comment, ResponseStatus responseStatus) {
         return Response.builder()
                 .member(member)
                 .request(request)
                 .comment(comment)
+                .status(responseStatus)
                 .build();
     }
 


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 승인권자가 여러명일 때 한 명이 승인하거나 거절했을 때 승인요청의 상태가 변경되는 버그 수정

# 연관 이슈
#163 

# 확인해야할 사항
- 승인권자가 여러명이 가능해지면서 여러명이 전부 승인해야 Request가 approved되는 것으로 처리되는 것이 자연스럽습니다.
  - 따라서 기존에 Request에만 승인상태를 저장하던 것을,  RequestStatus에 APPROVING이라는 상태를 추가하고, ResponseStatus를 정의한 뒤 Response에 status(APPROVED, REJECTED)를 추가하였습니다.
- 아래는 Request의 승인 상태 변경 규칙입니다.
  - 승인권자들이 아무도 승인/거절 하지 않으면 : 대기중
    1명이라도 거절하면 : 거절됨  
    1~(n-1)명 승인하면: 승인중  
    n명 승인하면: 승인됨

# 이후 계획
승인요청에 대해 승인권자의 일부가 거절하면 거절됨으로 표시되고, 이에 대해 승인요청한 사람은 "재요청"을 할 수 있게 하려고합니다. 
이때 승인요청하는 사람이 거절한 사람에 대해서만 승인권자를 지정하거나 요청이 수정됐으니 재확인하라는 측면에서 승인했던 사람들도 지정할 수 있습니다. (승인요청자의 책임입니다). 즉 댓글의 대댓글처럼, 게시글의 답글처럼 승인요청에 대해서도 재승인요청을 만들 계획입니다.

Closed #163 