### PR TITLE
[Feature] 재승인요청 기능 개발

### DIFF
--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -40,6 +40,15 @@ public class RequestController {
         return ResponseEntity.ok(ApiResponseForm.success(requestCreateResponse));
     }
 
+    @PostMapping("/requests/{requestId}/re-requests")
+    public ResponseEntity<ApiResponseForm<?>> createReRequest(@PathVariable Long requestId,
+                                                              @RequestBody ReRequestCreateRequest reRequestCreateRequest,
+                                                              HttpServletRequest request) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        ReRequestCreateResponse reRequestCreateResponse = requestService.createReRequest(memberId, reRequestCreateRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(reRequestCreateResponse));
+    }
+
     @GetMapping("/projects/{projectId}/requests")
     public ResponseEntity<ApiResponseForm<?>> getRequests(@PathVariable Long projectId,
                                                                  @ModelAttribute GetRequestCondition condition,

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -42,11 +42,11 @@ public class RequestController {
 
     @PostMapping("/requests/{requestId}/re-requests")
     public ResponseEntity<ApiResponseForm<?>> createReRequest(@PathVariable Long requestId,
-                                                              @RequestBody ReRequestCreateRequest reRequestCreateRequest,
+                                                              @RequestBody RequestCreateRequest requestCreateRequest,
                                                               HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        ReRequestCreateResponse reRequestCreateResponse = requestService.createReRequest(memberId, reRequestCreateRequest);
-        return ResponseEntity.ok(ApiResponseForm.success(reRequestCreateResponse));
+        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(requestCreateResponse));
     }
 
     @GetMapping("/projects/{projectId}/requests")

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -42,10 +42,10 @@ public class RequestController {
 
     @PostMapping("/requests/{requestId}/re-requests")
     public ResponseEntity<ApiResponseForm<?>> createReRequest(@PathVariable Long requestId,
-                                                              @RequestBody RequestCreateRequest requestCreateRequest,
+                                                              @RequestBody ReRequestCreateRequest reRequestCreateRequest,
                                                               HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestCreateResponse requestCreateResponse = requestService.createRequest(memberId, requestCreateRequest);
+        RequestCreateResponse requestCreateResponse = requestService.createReRequest(memberId, requestId, reRequestCreateRequest);
         return ResponseEntity.ok(ApiResponseForm.success(requestCreateResponse));
     }
 

--- a/src/main/java/com/soda/request/dto/request/ReRequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/ReRequestCreateRequest.java
@@ -11,9 +11,6 @@ import java.util.List;
 public class ReRequestCreateRequest {
     private String title;
     private String content;
-    private Long projectId;
-    private Long stageId;
-    private Long parentId;
     private List<LinkUploadRequest.LinkUploadDTO> links;
     private List<MemberAssignDTO> members;
 }

--- a/src/main/java/com/soda/request/dto/request/ReRequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/ReRequestCreateRequest.java
@@ -1,0 +1,19 @@
+package com.soda.request.dto.request;
+
+import com.soda.common.link.dto.LinkUploadRequest;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ReRequestCreateRequest {
+    private String title;
+    private String content;
+    private Long projectId;
+    private Long stageId;
+    private Long parentId;
+    private List<LinkUploadRequest.LinkUploadDTO> links;
+    private List<MemberAssignDTO> members;
+}

--- a/src/main/java/com/soda/request/dto/request/ReRequestCreateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/ReRequestCreateResponse.java
@@ -10,10 +10,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
 @Builder
 @Getter
-public class RequestCreateResponse {
+public class ReRequestCreateResponse {
     private Long requestId;
     private Long stageId;
     private Long memberId;
@@ -26,13 +25,13 @@ public class RequestCreateResponse {
     private RequestStatus status;
     private LocalDateTime createdAt;
 
-    public static RequestCreateResponse fromEntity(Request request) {
-        return RequestCreateResponse.builder()
+    public static ReRequestCreateResponse fromEntity(Request request) {
+        return ReRequestCreateResponse.builder()
                 .requestId(request.getId())
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
-                .parentId(request.getParentId() == null ? null : request.getParentId())
+                .parentId(request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(

--- a/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateRequest.java
@@ -13,6 +13,7 @@ public class RequestCreateRequest {
     private String content;
     private Long projectId;
     private Long stageId;
+    private Long parentId;
     private List<LinkUploadRequest.LinkUploadDTO> links;
     private List<MemberAssignDTO> members;
 

--- a/src/main/java/com/soda/request/dto/request/RequestDTO.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDTO.java
@@ -18,6 +18,7 @@ public class RequestDTO {
     private Long stageId;
     private Long memberId;
     private String memberName;
+    private Long parentId;
     private String title;
     private String content;
     private List<LinkDTO> links;
@@ -34,6 +35,7 @@ public class RequestDTO {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
+                .parentId(request.getParentId() == null ? null : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(

--- a/src/main/java/com/soda/request/dto/request/RequestDeleteResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDeleteResponse.java
@@ -14,6 +14,7 @@ public class RequestDeleteResponse {
     private Long stageId;
     private Long memberId;
     private String memberName;
+    private Long parentId;
     private String title;
     private String content;
     private RequestStatus status;
@@ -26,6 +27,7 @@ public class RequestDeleteResponse {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
+                .parentId(request.getParentId() == null ? null : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .status(request.getStatus())

--- a/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
@@ -17,6 +17,7 @@ public class RequestUpdateResponse {
     private Long stageId;
     private Long memberId;
     private String memberName;
+    private Long parentId;
     private String title;
     private String content;
     private List<LinkDTO> links;
@@ -31,6 +32,7 @@ public class RequestUpdateResponse {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
+                .parentId(request.getParentId() == null ? null : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -38,6 +38,8 @@ public class Request extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    private Long parentId;
+
     @TrackUpdate
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
     private List<RequestFile> files;

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -59,6 +59,7 @@ public class Request extends BaseEntity {
     public Request(Member member, Stage stage, Long parentId, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
         this.member = member;
         this.stage = stage;
+        this.parentId = parentId;
         this.title = title;
         this.status = status;
         this.content = content;

--- a/src/main/java/com/soda/request/entity/Request.java
+++ b/src/main/java/com/soda/request/entity/Request.java
@@ -56,7 +56,7 @@ public class Request extends BaseEntity {
     private List<Response> responses;
 
     @Builder
-    public Request(Member member, Stage stage, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
+    public Request(Member member, Stage stage, Long parentId, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
         this.member = member;
         this.stage = stage;
         this.title = title;

--- a/src/main/java/com/soda/request/error/RequestErrorCode.java
+++ b/src/main/java/com/soda/request/error/RequestErrorCode.java
@@ -11,7 +11,7 @@ public enum RequestErrorCode implements ErrorCode {
     REQUEST_LINK_NOT_FOUND("3005", "This request_link is not found" , HttpStatus.NOT_FOUND ),
     USER_NOT_UPLOAD_LINK("3006", "This user didn't upload the request_link" , HttpStatus.BAD_REQUEST ),
     USER_IS_NOT_APPROVER("3007", "This user is not approver", HttpStatus.BAD_REQUEST ),
-    ;
+    REQUEST_NOT_REJECTED("3008", "This request is not rejected" , HttpStatus.BAD_REQUEST ),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -124,7 +124,7 @@ public class RequestService {
     }
 
     private static boolean isAllApproversApproved(Request request) {
-        return request.getResponses().stream().filter(response -> response.getStatus() == ResponseStatus.APPROVED).count() == request.getApprovers().size();
+        return request.getResponses().stream().filter(response -> response.getStatus() == ResponseStatus.APPROVED && !response.getIsDeleted()).count() == request.getApprovers().size();
     }
 
     @Transactional

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -74,10 +74,17 @@ public class RequestService {
         Stage stage = getStageOrThrow(parentRequest.getStage().getId());
 
         validateProjectAuthority(member, parentRequest.getStage().getProject().getId());
+        validateRequestStatus(parentRequest);
 
         Request reRequest = createReRequest(reRequestCreateRequest, requestId, member, stage);
 
         return RequestCreateResponse.fromEntity(reRequest);
+    }
+
+    private void validateRequestStatus(Request parentRequest) {
+        if (parentRequest.getStatus() != RequestStatus.REJECTED) {
+            throw new GeneralException(RequestErrorCode.REQUEST_NOT_REJECTED);
+        }
     }
 
     public Page<RequestDTO> findRequests(GetRequestCondition condition, Pageable pageable) {

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -66,6 +66,20 @@ public class RequestService {
         return RequestCreateResponse.fromEntity(request);
     }
 
+    @LoggableEntityAction(action = "CREATE", entityClass = Request.class)
+    @Transactional
+    public RequestCreateResponse createReRequest(Long memberId, Long requestId, ReRequestCreateRequest reRequestCreateRequest) {
+        Request parentRequest = getRequestOrThrow(requestId);
+        Member member = getMemberWithProjectOrThrow(memberId);
+        Stage stage = getStageOrThrow(parentRequest.getStage().getId());
+
+        validateProjectAuthority(member, parentRequest.getStage().getProject().getId());
+
+        Request reRequest = createReRequest(reRequestCreateRequest, requestId, member, stage);
+
+        return RequestCreateResponse.fromEntity(reRequest);
+    }
+
     public Page<RequestDTO> findRequests(GetRequestCondition condition, Pageable pageable) {
         return requestRepository.searchByCondition(condition, pageable)
                 .map(RequestDTO::fromEntity);
@@ -192,7 +206,15 @@ public class RequestService {
     }
 
     public Request createRequest(RequestCreateRequest dto, Member member, Stage stage) {
-        Request request = buildRequest(dto, member, stage);
+        Request request = buildRequest(dto.getTitle(), dto.getContent(), dto.getParentId(), member, stage);
+        List<RequestLink> requestLinks = linkService.buildLinks("request", request, dto.getLinks());
+        request.addLinks(requestLinks);
+        designateApprover(dto.getMembers(), request);
+        return requestRepository.save(request);
+    }
+
+    private Request createReRequest(ReRequestCreateRequest dto, Long requestId, Member member, Stage stage) {
+        Request request = buildRequest(dto.getTitle(), dto.getContent(), requestId, member, stage);
         List<RequestLink> requestLinks = linkService.buildLinks("request", request, dto.getLinks());
         request.addLinks(requestLinks);
         designateApprover(dto.getMembers(), request);
@@ -213,13 +235,13 @@ public class RequestService {
         request.addApprovers(ApproverDesignation.designateApprover(request, approvers));
     }
 
-    private Request buildRequest(RequestCreateRequest dto, Member member, Stage stage) {
+    private Request buildRequest(String title, String content, Long parentId, Member member, Stage stage) {
         return Request.builder()
                 .member(member)
                 .stage(stage)
-                .title(dto.getTitle())
-                .content(dto.getContent())
-                .parentId(dto.getParentId()==null ? null : dto.getParentId())
+                .title(title)
+                .content(content)
+                .parentId(parentId==null ? null : parentId)
                 .status(RequestStatus.PENDING)
                 .build();
     }

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -219,6 +219,7 @@ public class RequestService {
                 .stage(stage)
                 .title(dto.getTitle())
                 .content(dto.getContent())
+                .parentId(dto.getParentId()==null ? null : dto.getParentId())
                 .status(RequestStatus.PENDING)
                 .build();
     }
@@ -226,4 +227,5 @@ public class RequestService {
     public void changeStatusToPending(Request request) {
         request.changeStatusToPending();
     }
+
 }


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
### 본 PR은 PR https://github.com/Kernel360/KDEV4-SODA-BE/pull/164 가 먼저 merge되고 난 후 리뷰 및 머지되어야합니다!!
- 승인요청에 대해 승인권자의 일부가 거절하면 거절됨으로 표시되고, 이에 대해 승인요청한 사람은 "재승인요청"을 할 수 있게 구현하였습니다.
  - 이 때 승인요청하는 사람이 거절한 사람에 대해서만 승인권자를 지정하거나 요청이 수정됐으니 재확인하라는 측면에서 승인했던 사람들도 지정할 수 있습니다. (승인요청자의 책임입니다). 즉 댓글의 대댓글처럼, 게시글의 답글처럼 승인요청에 대해서도 재승인요청을 구현하였습니다.

# 연관 이슈
#165 

# 확인해야할 사항
- 특정 승인요청에 대해 거절되었을 경우 재승인요청을 보낼 수 있는 기능을 구현하였음.
  - POST requests/{requestId}/re-requests
  - 승인이 거절되었을 경우만 재승인요청을 보낼 수 있으며 이 때 생성되는 승인요청은 일반 승인요청과 똑같이 필드가 들어감(제목, 내용, 링크, 파일, 승인권자)
  - 승인권자도 재지정할 수 있음.
    - 승인요청자가 거절한 사람만 지정하거나 내용이 변경되었으므로 승인한 사람도 다시 봐야한다고 판단하면 승인권자를 전체로 할 수도 있음. 상황에 따라 유동적이기 때문에 재승인요청에서 승인권자 지정 책임을 승인요청자에게 넘겼음.
- 재승인요청은 기본적으로 승인요청 테이블에 들어가므로 수정/삭제/조회 등은 일반 승인요청에서 하는것 처럼 하면 됨.