### PR TITLE
[Refactor] Request 수정 요청시 로깅에서 500에러 뜨는 버그 해결

### DIFF
--- a/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
+++ b/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
@@ -12,7 +12,9 @@ import com.soda.global.log.dataLog.annotation.LoggableEntityAction;
 import com.soda.global.log.dataLog.domain.DataLog;
 import com.soda.global.log.dataLog.domain.DataLogRepository;
 import com.soda.member.dto.company.CompanyResponse;
+import com.soda.member.dto.company.MemberResponse;
 import com.soda.member.entity.Company;
+import com.soda.member.entity.Member;
 import com.soda.project.dto.ProjectDTO;
 import com.soda.project.dto.stage.StageResponse;
 import com.soda.project.entity.Project;
@@ -58,7 +60,7 @@ public class EntityLogAspect {
     private static final Map<Class<?>, Function<Object, Object>> dtoConverters = new HashMap<>();
 
     static {
-//        dtoConverters.put(Member.class, e -> MemberDTO.fromEntity((Member) e)); // 멤버 조회 DTO가 아직 없어 주석처리 해두었음
+        dtoConverters.put(Member.class, e -> MemberResponse.fromEntity((Member) e)); // 멤버 조회 DTO가 아직 없어 주석처리 해두었음
         dtoConverters.put(Company.class, e -> CompanyResponse.fromEntity((Company) e));
 
         dtoConverters.put(Project.class, e -> ProjectDTO.fromEntity((Project) e));
@@ -144,6 +146,7 @@ public class EntityLogAspect {
         for (String key : after.keySet()) {
             Object beforeVal = before.getOrDefault(key, "N/A"); // 디폴트 값 설정
             Object afterVal = after.getOrDefault(key, "N/A");
+            System.out.println(beforeVal + " and " + afterVal);
             if (!Objects.equals(beforeVal, afterVal)) {
                 diff.put(key, Map.of("before", beforeVal, "after", afterVal));
             }

--- a/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
+++ b/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
@@ -146,7 +146,6 @@ public class EntityLogAspect {
         for (String key : after.keySet()) {
             Object beforeVal = before.getOrDefault(key, "N/A"); // 디폴트 값 설정
             Object afterVal = after.getOrDefault(key, "N/A");
-            System.out.println(beforeVal + " and " + afterVal);
             if (!Objects.equals(beforeVal, afterVal)) {
                 diff.put(key, Map.of("before", beforeVal, "after", afterVal));
             }

--- a/src/main/java/com/soda/request/dto/request/ReRequestCreateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/ReRequestCreateResponse.java
@@ -36,6 +36,7 @@ public class ReRequestCreateResponse {
                 .content(request.getContent())
                 .links(
                         request.getLinks().stream()
+                                .filter(link -> !link.getIsDeleted())
                                 .map(LinkDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )

--- a/src/main/java/com/soda/request/dto/request/RequestCreateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestCreateResponse.java
@@ -32,11 +32,12 @@ public class RequestCreateResponse {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
-                .parentId(request.getParentId() == null ? null : request.getParentId())
+                .parentId(request.getParentId() == null ? -1 : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(
                         request.getLinks().stream()
+                                .filter(link -> !link.getIsDeleted())
                                 .map(LinkDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )

--- a/src/main/java/com/soda/request/dto/request/RequestDTO.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDTO.java
@@ -35,7 +35,7 @@ public class RequestDTO {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
-                .parentId(request.getParentId() == null ? null : request.getParentId())
+                .parentId(request.getParentId() == null ? -1 : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(

--- a/src/main/java/com/soda/request/dto/request/RequestDeleteResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDeleteResponse.java
@@ -27,7 +27,7 @@ public class RequestDeleteResponse {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
-                .parentId(request.getParentId() == null ? null : request.getParentId())
+                .parentId(request.getParentId() == null ? -1 : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .status(request.getStatus())

--- a/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
+++ b/src/main/java/com/soda/request/dto/request/RequestUpdateResponse.java
@@ -32,11 +32,12 @@ public class RequestUpdateResponse {
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())
-                .parentId(request.getParentId() == null ? null : request.getParentId())
+                .parentId(request.getParentId() == null ? -1 : request.getParentId())
                 .title(request.getTitle())
                 .content(request.getContent())
                 .links(
                         request.getLinks().stream()
+                                .filter(link -> !link.getIsDeleted())
                                 .map(LinkDTO::fromEntity)
                                 .collect(Collectors.toList())
                 )


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- Request 수정 요청시 로깅에서 500에러 뜨는 버그 해결

# 연관 이슈
#169 

# 확인해야할 사항
- Request에 ParentId필드가 추가되면서 응답DTO의 fromEntity에서 parentId가 null이면 null을 반환하게 처리하였는데, null일 경우 로깅시 500에러가 발생.
- parentId가 null이면 -1을 반환하게 수정하여 해결하였음.

Closed #169 