### PR TITLE
[Fix] 사용자가 참여 중인 프로젝트 목록이 없으면 경우 오류 수정

### DIFF
--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -160,6 +160,12 @@ public class ProjectService {
             Page<Long> projectIds = memberProjectService.getProjectIdsByUserId(userId, pageable);
             log.info("사용자 ID = {}가 참여한 프로젝트 ID 목록 조회 완료: 조회된 프로젝트 수 = {}", userId, projectIds.getSize());
 
+            // 사용자가 참여 중인 프로젝트가 없는 경우
+            if (projectIds.isEmpty()) {
+                log.info("사용자 ID = {}가 참여한 프로젝트가 없습니다. 빈 목록 반환", userId);
+                return Page.empty(pageable);
+            }
+
             Page<Project> userProjectPage = projectRepository.findByIdIn(projectIds.getContent(), pageable);
             log.info("사용자 ID = {}에 대한 프로젝트 목록 조회 완료: 조회된 프로젝트 수 = {}", userId, userProjectPage.getSize());
 


### PR DESCRIPTION
# 요약
사용자가 참여 중인 프로젝트가 없는 경우 오류가 발생하는 부분을 수정하였습니다.

# 연관 이슈
#190 


# 확인사항
- `/projects/my` API를 통해 사용자가 참여 중인 프로젝트 목록 조회 시, 참여 중인 프로젝트가 없는 경우 오류가 발생하였습니다.
- 오류 발생 대신 빈 리스트가 출력되도록 수정하였습니다.

Closed #190
