### PR TITLE
[Feature] 사용자의 회사가 참여 중인 프로젝트 목록 조회 기능

### DIFF
--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -48,11 +48,11 @@ public class ProjectController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<ApiResponseForm<Page<ProjectListResponse>>> getMyProjects(HttpServletRequest request,
+    public ResponseEntity<ApiResponseForm<Page<MyProjectListResponse>>> getMyProjects(HttpServletRequest request,
                                                                                     @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Long userId = (Long) request.getAttribute("memberId");
         String userRole = (String) request.getAttribute("userRole").toString();
-        Page<ProjectListResponse> response = projectService.getMyProjects(userId, userRole, pageable);
+        Page<MyProjectListResponse> response = projectService.getMyProjects(userId, userRole, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 
@@ -127,5 +127,13 @@ public class ProjectController {
     ) {
         Page<ProjectMemberResponse> memberPage = projectService.getProjectMembers(projectId, searchCondition, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(memberPage));
+    }
+
+    @GetMapping("/my-company")
+    public ResponseEntity<ApiResponseForm<Page<MyProjectListResponse>>> getMyCompanyProjects (HttpServletRequest request,
+                                                                          @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Long userId = (Long) request.getAttribute("memberId");
+        Page<MyProjectListResponse> response = projectService.getMyCompanyProjects(userId, pageable);
+        return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 }

--- a/src/main/java/com/soda/project/dto/MyProjectListResponse.java
+++ b/src/main/java/com/soda/project/dto/MyProjectListResponse.java
@@ -1,0 +1,36 @@
+package com.soda.project.dto;
+
+import com.soda.member.enums.CompanyProjectRole;
+import com.soda.member.enums.MemberProjectRole;
+import com.soda.project.entity.Project;
+import com.soda.project.enums.ProjectStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyProjectListResponse {
+
+    private Long projectId;
+    private String title;
+    private ProjectStatus status;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private CompanyProjectRole companyProjectRole;
+    private MemberProjectRole memberProjectRole;
+
+    public static MyProjectListResponse from(Project project, CompanyProjectRole companyProjectRole, MemberProjectRole memberProjectRole) {
+        return MyProjectListResponse.builder()
+                .projectId(project.getId())
+                .title(project.getTitle())
+                .status(project.getStatus())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .companyProjectRole(companyProjectRole)
+                .memberProjectRole(memberProjectRole)
+                .build();
+    }
+
+}

--- a/src/main/java/com/soda/project/repository/ProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
 
     // 전체 프로젝트 목록 최신순 조회
     Page<Project> findByIsDeletedFalse(Pageable pageable);

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.soda.project.repository;
+
+import com.querydsl.core.Tuple;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProjectRepositoryCustom {
+    Page<Tuple> findMyProjectsData(Long memberId, Pageable pageable);
+
+    Page<Tuple> findMyCompanyProjectsData(Long memberId, Long companyId, Pageable pageable);
+}

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
@@ -3,8 +3,6 @@ package com.soda.project.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.soda.member.entity.QCompany;
-import com.soda.member.entity.QMember;
 import com.soda.project.entity.QCompanyProject;
 import com.soda.project.entity.QMemberProject;
 import com.soda.project.entity.QProject;

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.soda.project.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soda.member.entity.QCompany;
+import com.soda.member.entity.QMember;
+import com.soda.project.entity.QCompanyProject;
+import com.soda.project.entity.QMemberProject;
+import com.soda.project.entity.QProject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QProject project = QProject.project;
+    private static final QMemberProject memberProject = QMemberProject.memberProject;
+    private static final QCompanyProject companyProject = QCompanyProject.companyProject;
+
+    @Override
+    public Page<Tuple> findMyProjectsData(Long memberId, Pageable pageable) {
+        List<Tuple> content = queryFactory
+                .select(
+                        project,             // Project 엔티티
+                        companyProject.companyProjectRole, // 회사 역할
+                        memberProject.role   // 멤버 역할
+                )
+                .from(project)
+                // 1. MemberProject와 조인하여 특정 멤버가 참여하는 프로젝트 필터링
+                .join(project.memberProjects, memberProject)
+                // 2. CompanyProject와 조인 (별도의 ON 조건 필요)
+                .join(project.companyProjects, companyProject)
+                // ON 조건: CompanyProject의 회사 ID가 MemberProject의 멤버가 속한 회사 ID와 같아야 함
+                .on(companyProject.company.id.eq(
+                        // 서브쿼리 대신 MemberProject의 member를 통해 company ID를 가져옴
+                        memberProject.member.company.id
+                ))
+                .where(
+                        // memberProject의 member ID가 주어진 memberId와 일치해야 함
+                        memberProject.member.id.eq(memberId),
+                        project.isDeleted.isFalse(),
+                        memberProject.isDeleted.isFalse(),
+                        companyProject.isDeleted.isFalse() // 회사 연결도 활성 상태
+                )
+                .orderBy(project.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Count 쿼리도 동일한 조인 및 조건 적용
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.countDistinct())
+                .from(project)
+                .join(project.memberProjects, memberProject)
+                .join(project.companyProjects, companyProject)
+                .on(companyProject.company.id.eq(memberProject.member.company.id))
+                .where(
+                        memberProject.member.id.eq(memberId),
+                        project.isDeleted.isFalse(),
+                        memberProject.isDeleted.isFalse(),
+                        companyProject.isDeleted.isFalse()
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<Tuple> findMyCompanyProjectsData(Long memberId, Long companyId, Pageable pageable) {
+        // (이전 답변과 동일 - LEFT JOIN 로직 유효)
+        List<Tuple> content = queryFactory
+                .select(
+                        project,             // Project 엔티티 전체
+                        companyProject.companyProjectRole, // 회사 역할
+                        memberProject.role   // 멤버 역할 (null 가능)
+                )
+                .from(project)
+                // 회사가 참여한 프로젝트 찾기 (INNER JOIN)
+                .join(project.companyProjects, companyProject)
+                // 현재 사용자의 멤버 역할 찾기 (LEFT JOIN)
+                .leftJoin(project.memberProjects, memberProject)
+                .on(memberProject.member.id.eq(memberId) // 현재 사용자이고
+                        .and(memberProject.isDeleted.isFalse())) // 삭제되지 않은 연결
+                .where(
+                        companyProject.company.id.eq(companyId), // 특정 회사 필터
+                        project.isDeleted.isFalse(),
+                        companyProject.isDeleted.isFalse() // 회사 연결 활성
+                )
+                .orderBy(project.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Count 쿼리 (회사 기준으로 count)
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.countDistinct())
+                .from(project)
+                .join(project.companyProjects, companyProject)
+                .where(
+                        companyProject.company.id.eq(companyId),
+                        project.isDeleted.isFalse(),
+                        companyProject.isDeleted.isFalse()
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}


### PR DESCRIPTION

# 요약
로그인한 사용자가 속한 회사가 참여 중인 프로젝트 목록 조회 기능 추가했습니다.


# 연관 이슈
#191 


# 확인 사항
### 1. `MyProjectListResponse` 새로 생성
- 사용자가 프로젝트 목록 조회할 때 해당 사용자의 role, 회사의 role이 필요해서 response를 새로 생성했습니다.
- 사용자가 참여 중인 프로젝트 목록 / 사용자의 회사가 참여 중인 프로젝트 목록 조회할 때 사용합니다.
### 2. custom repository 생성
- getMyProjectsData 메서드에서는 Project, MemberProject, CompanyProject 세 엔티티를 조인해야 해서 복잡한 조인과 조건을 타입 안전하고 명확하게 표현할 수 있게 따로 생성하였습니다.
### 3. Tuple 사용 이유
- Tuple은 QueryDSL에서 여러 타입의 조회 결과를 하나의 묶음으로 반환하기 위한 객체입니다. 
- @QueryProjection을 사용하지 않고 리포지토리에서 다양한 데이터를 조합하여 반환해야 할 때 유용하다고 해서 적용했습니다.
- 리포지토리는 데이터 조회 책임만 지고 서비스에서 최종 DTO 변환을 수행하도록 관심사를 분리할 수 있습니다.
- 서비스에서는 tuple.get(index, Type.class)를 통해 Tuple 내부의 데이터에 접근합니다.


Closed #191 