### PR TITLE
[Feature] 사용자가 작성한 게시글 목록 조회 기능

### DIFF
--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -11,6 +11,8 @@ import com.soda.global.response.ApiResponseForm;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -101,6 +103,16 @@ public class ArticleController {
         Long memberId = (Long) request.getAttribute("memberId");
         List<RecentArticleResponse> recentArticles = articleService.getRecentArticlesForUser(memberId);
         return ResponseEntity.ok(ApiResponseForm.success(recentArticles));
+    }
+
+    @GetMapping("/articles/my")
+    public ResponseEntity<ApiResponseForm<Page<MyArticleListResponse>>> getMyArticles(HttpServletRequest request,
+                                                                                      @RequestParam(required = false) Long projectId,
+                                                                                      Pageable pageable
+                                                                                      ) {
+        Long memberId = (Long) request.getAttribute("memberId");
+        Page<MyArticleListResponse> response = articleService.getMyArticles(memberId, projectId, pageable);
+        return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 
     @PostMapping("/articles/{articleId}/vote")

--- a/src/main/java/com/soda/article/dto/article/MyArticleListResponse.java
+++ b/src/main/java/com/soda/article/dto/article/MyArticleListResponse.java
@@ -17,7 +17,15 @@ public class MyArticleListResponse {
     private String stageName;
     private LocalDateTime createdAt;
 
-    public static MyArticleListResponse from() {
-        return null;
+    public static MyArticleListResponse from(Long articleId, String title, Long projectId, String projName, Long stageId, String stageName, LocalDateTime createdAt) {
+        return MyArticleListResponse.builder()
+                .articleId(articleId)
+                .title(title)
+                .projectId(projectId)
+                .projectName(projName)
+                .stageId(stageId)
+                .stageName(stageName)
+                .createdAt(createdAt)
+                .build();
     }
 }

--- a/src/main/java/com/soda/article/dto/article/MyArticleListResponse.java
+++ b/src/main/java/com/soda/article/dto/article/MyArticleListResponse.java
@@ -1,0 +1,23 @@
+package com.soda.article.dto.article;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyArticleListResponse {
+
+    private Long projectId;
+    private Long articleId;
+    private String title;
+    private String projectName;
+    private Long stageId;
+    private String stageName;
+    private LocalDateTime createdAt;
+
+    public static MyArticleListResponse from() {
+        return null;
+    }
+}

--- a/src/main/java/com/soda/article/error/ArticleErrorCode.java
+++ b/src/main/java/com/soda/article/error/ArticleErrorCode.java
@@ -12,7 +12,8 @@ public enum ArticleErrorCode implements ErrorCode {
     USER_NOT_UPLOAD_ARTICLE_FILE("1106", "해당 사용자가 업로드한 게시글 파일이 아닙니다.", HttpStatus.NOT_FOUND),
     ARTICLE_LINK_NOT_FOUND("1107", "해당 게시글의 링크를 찾을 수 없습니다." , HttpStatus.NOT_FOUND ),
     USER_NOT_UPLOAD_ARTICLE_LINK("1108", "해당 사용자가 업로드한 게시글 링크가 아닙니다." , HttpStatus.NOT_FOUND ),
-    NO_PERMISSION_TO_MODIFY_ARTICLE("1109", "게시글 작성자만 투표를 생성할 수 있습니다.", HttpStatus.FORBIDDEN);
+    NO_PERMISSION_TO_MODIFY_ARTICLE("1109", "게시글 작성자만 투표를 생성할 수 있습니다.", HttpStatus.FORBIDDEN),
+    ARTICLE_DATA_CONVERSION_ERROR("1110", "게시글 데이터 조회 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/article/repository/ArticleRepository.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleRepositoryCustom{
     // isDeleted가 false인 게시글만 조회하고, 특정 Project에 속한 게시글만 조회
     List<Article> findByIsDeletedFalseAndStage_Project(Project project);
 

--- a/src/main/java/com/soda/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.soda.article.repository;
+
+import com.querydsl.core.Tuple;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ArticleRepositoryCustom {
+
+    Page<Tuple> findMyArticlesData(Long authorId, Long projectId, Pageable pageable);
+
+}

--- a/src/main/java/com/soda/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepositoryImpl.java
@@ -1,0 +1,79 @@
+package com.soda.article.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.soda.article.entity.QArticle.article;
+import static com.soda.project.entity.QProject.project;
+import static com.soda.project.entity.QStage.stage;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Tuple> findMyArticlesData(Long authorId, Long projectId, Pageable pageable) {
+
+        List<Tuple> content = queryFactory
+                .select( // DTO 필드 순서에 맞춰 데이터 선택
+                        article.id,        // articleId
+                        article.title,     // title
+                        project.id,        // projectId (stage를 통해 조인)
+                        project.title,     // projectName (stage를 통해 조인)
+                        stage.id,          // stageId
+                        stage.name,   // stageName
+                        article.createdAt  // createdAt
+                )
+                .from(article)
+                // Article -> Stage 조인
+                .join(article.stage, stage)
+                // Stage -> Project 조인 (Stage 엔티티에 'project' 필드가 있다고 가정)
+                .join(stage.project, project)
+                // Article -> Member 조인 (where 절에서만 사용하므로 명시적 조인 불필요 가능하나, 가독성을 위해 포함)
+                // .join(article.member, member) // member Q 클래스 정의 필요
+                .where(
+                        // article.member 필드를 통해 바로 작성자 ID 비교
+                        article.member.id.eq(authorId),
+                        article.isDeleted.isFalse(),
+                        // projectIdEq 헬퍼 메서드는 project 별칭을 사용
+                        projectIdEq(projectId)
+                )
+                .orderBy(article.createdAt.desc()) // 최신순 정렬
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // Count 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(article.count())
+                .from(article)
+                // where 조건에서 project.id를 사용하므로 조인이 필요함
+                .join(article.stage, stage)
+                .join(stage.project, project)
+                // .join(article.member, member) // where 조건에서만 사용 시 count 쿼리 조인 불필요 가능
+                .where(
+                        article.member.id.eq(authorId),
+                        article.isDeleted.isFalse(),
+                        projectIdEq(projectId)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    // 프로젝트 ID 필터링 조건 (project 별칭 사용)
+    private BooleanExpression projectIdEq(Long projectId) {
+        // projectId가 null이 아니고 유효한 값일 때만 project.id 와 비교
+        return (projectId != null && projectId > 0) ? project.id.eq(projectId) : null;
+    }
+}

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -372,15 +372,7 @@ public class ArticleService {
         }
 
         // DTO 생성
-        return MyArticleListResponse.builder()
-                .articleId(articleId)
-                .title(title)
-                .projectId(projId)
-                .projectName(projName)
-                .stageId(stgId)
-                .stageName(stgName)
-                .createdAt(createdAt)
-                .build();
+        return MyArticleListResponse.from(articleId, title, projId, projName, stgId, stgName, createdAt);
     }
 
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -1,5 +1,6 @@
 package com.soda.article.service;
 
+import com.querydsl.core.Tuple;
 import com.soda.article.dto.article.*;
 import com.soda.article.entity.Article;
 import com.soda.article.entity.ArticleLink;
@@ -20,10 +21,13 @@ import com.soda.project.service.ProjectService;
 import com.soda.project.service.StageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -322,4 +326,61 @@ public class ArticleService {
 
         return voteResponse;
     }
+
+    public Page<MyArticleListResponse> getMyArticles(Long userId, Long projectId, Pageable pageable) {
+        log.info("사용자 ID {}가 작성한 게시글 목록 조회 시작. 프로젝트 필터 ID: {}", userId, projectId != null ? projectId : "없음");
+
+        // 1. 리포지토리 호출하여 Tuple 데이터 조회
+        Page<Tuple> tuplePage = fetchMyArticlesData(userId, projectId, pageable);
+
+        // 2. 조회된 Tuple 데이터를 DTO로 변환 (헬퍼 메서드 사용)
+        Page<MyArticleListResponse> responsePage = convertToMyArticleListResponsePage(tuplePage);
+
+        log.info("사용자 ID {} 작성 게시글 목록 조회 완료. 조회된 게시글 수: {}", userId, responsePage.getTotalElements());
+        return responsePage;
+    }
+
+    private Page<Tuple> fetchMyArticlesData(Long userId, Long projectId, Pageable pageable) {
+        return articleRepository.findMyArticlesData(userId, projectId, pageable);
+    }
+
+    private Page<MyArticleListResponse> convertToMyArticleListResponsePage(Page<Tuple> tuplePage) {
+        if (tuplePage.isEmpty()) {
+            log.info("변환할 게시글 데이터(Tuple)가 없습니다.");
+            return Page.empty(tuplePage.getPageable());
+        } else {
+            log.debug("조회된 Tuple 데이터를 MyArticleListResponse DTO로 변환 시작. 변환 대상 수: {}", tuplePage.getNumberOfElements());
+        }
+
+        return tuplePage.map(this::mapTupleToMyArticleResponse);
+    }
+
+    private MyArticleListResponse mapTupleToMyArticleResponse(Tuple tuple) {
+        // Tuple에서 데이터 추출
+        Long articleId = tuple.get(0, Long.class);
+        String title = tuple.get(1, String.class);
+        Long projId = tuple.get(2, Long.class);
+        String projName = tuple.get(3, String.class);
+        Long stgId = tuple.get(4, Long.class);
+        String stgName = tuple.get(5, String.class);
+        LocalDateTime createdAt = tuple.get(6, LocalDateTime.class);
+
+        // null 체크
+        if (articleId == null) {
+            log.error("mapTupleToMyArticleResponse - Tuple에서 필수 데이터 누락: tuple={}", tuple);
+            throw new GeneralException(ArticleErrorCode.ARTICLE_DATA_CONVERSION_ERROR);
+        }
+
+        // DTO 생성
+        return MyArticleListResponse.builder()
+                .articleId(articleId)
+                .title(title)
+                .projectId(projId)
+                .projectName(projName)
+                .stageId(stgId)
+                .stageName(stgName)
+                .createdAt(createdAt)
+                .build();
+    }
+
 }


### PR DESCRIPTION

# 요약
사용자가 작성한 게시글 목록 조회 기능


# 연관 이슈
#198 

# 확인 사항
### 1. 프로젝트별 필터링 기능 추가
- 기본적으로 사용자가 작성한 게시글 목록 조회 기능을 구현했습니다.
- `@RequestParam(required = false) Long projectId`를 통해 프로젝트 별로 필터링할 수 있습니다.
- 페이지네이션 적용했습니다.
### 2. custom repository 생성
- ArticleRepositoryImpl에 QueryDSL을 사용한 findMyArticlesData 구현
- Article, Stage, Project 조인을 위해 생성
- select() 절을 사용하여 DTO 필드에 필요한 데이터를 Tuple로 조회.
- where() 절에 작성자 ID, 삭제 여부, 동적 projectId 필터링 조건 적용.
- 페이징 및 기본 정렬 적용.
### 3. Tuple -> MyProjectlListResponse 생성을 위해 private method 생성
- Tuple에서 데이터를 추출하고 @Builder를 사용하여 DTO 생성


close #198 