### PR TITLE
[Feature] Request 작성자, 승인권자, 프로젝트(선택)을 바탕으로 조회하는 API 구현

### DIFF
--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -61,7 +61,7 @@ public class RequestController {
     public ResponseEntity<ApiResponseForm<?>> getMemberRequests(@PathVariable Long memberId,
                                                                 @ModelAttribute GetMemberRequestCondition condition,
                                                                 Pageable pageable) {
-        Page<RequestDTO> requests = requestService.findMemberRequests(condition, pageable);
+        Page<RequestDTO> requests = requestService.findMemberRequests(memberId, condition, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(requests));
     }
 

--- a/src/main/java/com/soda/request/controller/RequestController.java
+++ b/src/main/java/com/soda/request/controller/RequestController.java
@@ -57,6 +57,14 @@ public class RequestController {
         return ResponseEntity.ok(ApiResponseForm.success(requests));
     }
 
+    @GetMapping("/members/{memberId}/requests")
+    public ResponseEntity<ApiResponseForm<?>> getMemberRequests(@PathVariable Long memberId,
+                                                                @ModelAttribute GetMemberRequestCondition condition,
+                                                                Pageable pageable) {
+        Page<RequestDTO> requests = requestService.findMemberRequests(condition, pageable);
+        return ResponseEntity.ok(ApiResponseForm.success(requests));
+    }
+
     @GetMapping("/stages/{stageId}/requests")
     public ResponseEntity<ApiResponseForm<?>> getAllRequests(@PathVariable Long stageId) {
         List<RequestDTO> requestDTOList = requestService.findAllByStageId(stageId);

--- a/src/main/java/com/soda/request/dto/request/GetMemberRequestCondition.java
+++ b/src/main/java/com/soda/request/dto/request/GetMemberRequestCondition.java
@@ -1,0 +1,14 @@
+package com.soda.request.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GetMemberRequestCondition {
+    private Long requesterId;
+    private Long approverId;
+    private Long projectId;
+}

--- a/src/main/java/com/soda/request/dto/request/GetMemberRequestCondition.java
+++ b/src/main/java/com/soda/request/dto/request/GetMemberRequestCondition.java
@@ -8,7 +8,5 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class GetMemberRequestCondition {
-    private Long requesterId;
-    private Long approverId;
     private Long projectId;
 }

--- a/src/main/java/com/soda/request/repository/RequestRepositoryCustom.java
+++ b/src/main/java/com/soda/request/repository/RequestRepositoryCustom.java
@@ -1,10 +1,13 @@
 package com.soda.request.repository;
 
 import com.soda.request.dto.GetRequestCondition;
+import com.soda.request.dto.request.GetMemberRequestCondition;
 import com.soda.request.entity.Request;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RequestRepositoryCustom {
     Page<Request> searchByCondition(GetRequestCondition condition, Pageable pageable);
+
+    Page<Request> searchByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/soda/request/service/RequestService.java
+++ b/src/main/java/com/soda/request/service/RequestService.java
@@ -92,6 +92,11 @@ public class RequestService {
                 .map(RequestDTO::fromEntity);
     }
 
+    public Page<RequestDTO> findMemberRequests(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
+        return requestRepository.searchByMemberCondition(memberId, condition, pageable)
+                .map(RequestDTO::fromEntity);
+    }
+
 
     public List<RequestDTO> findAllByStageId(Long stageId) {
         return requestRepository.findAllByStage_IdAndIsDeletedFalse(stageId).stream()


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- Request 작성자, 승인권자, 프로젝트(선택)을 바탕으로 조회하는 API 구현

# 연관 이슈
#193 

# 확인해야할 사항
- 사용자 대시보드의 "최근 요청사항", 내 요청사항 목록에서 사용되는 API입니다.
- GET members/{memberId}/requests?projectId
  - Request의 작성자 "or" 승인권자 == memberId인 Request를 페이지네이션하여 조회해옵니다. 
  이 때, projectId를 쿼리파라미터로 넣어 필터링 조건으로 사용할 수 있습니다.
    - 저희 시스템은 회원가입 시점에 고객사/개발사인지 정해지는 것이 아니라 프로젝트 생성 시점에 정해지기 때문에, 현재 로그인한 일반사용자의 대시보드에서 "내가 최근 요청한 승인요청 목록"/"내가 최근 요청받은 승인요청 목록" 을 둘 다 보여주면 사용자 경험이 좋지 않습니다. (회사의 특성상 일반적으로 한 유저는 개발사로서만, 고객사로서만 활동할 가능성이 크기 때문입니다.) 따라서 "최근 요청사항"이라고 대시보드 요소를 뭉뚱그리고 여기에 "내가 최근 요청한 승인요청 목록"/"내가 최근 요청받은 승인요청 목록"을 함께 보여주는 방식으로 화면 구성하였습니다. 
- Fetch Join
  - Request의 승인권자를 조회할 때 ApproveDesignation이라는 엔티티에 접근해야하는데 이 때 n+1문제가 발생할 수 있어, 처음 Request를 QueryDSL로 가져올 때 승인권자지정 테이블을 Fetch JOIN하여 가져오는 방식으로 n+1문제를 예방하였습니다.
  - 사실 이 API 이외의 여러 API의 리포지토리 메서드를 보면 n+1이 발생할 수 있는 쿼리들이 많은데 이 쿼리들도 차차 개선해나가야할 것 같습니다. 그러기 위해선 구현을 얼른 해야함니다..!!
