### PR TITLE
[Feature] 데이터 로그 키워드 검색 기능 구현

### DIFF
--- a/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
+++ b/src/main/java/com/soda/global/log/dataLog/aspect/EntityLogAspect.java
@@ -127,7 +127,9 @@ public class EntityLogAspect {
                 .operator(operator)
                 .timestamp(LocalDateTime.now())
                 .beforeData(beforeData)
+                .beforeDataText(objectMapper.writeValueAsString(beforeData))
                 .afterData(afterData)
+                .afterDataText(objectMapper.writeValueAsString(afterData))
                 .diff(diff)
                 .build();
 

--- a/src/main/java/com/soda/global/log/dataLog/domain/DataLog.java
+++ b/src/main/java/com/soda/global/log/dataLog/domain/DataLog.java
@@ -23,4 +23,7 @@ public class DataLog {
     private Map<String, Object> beforeData; // UPDATE/DELETE 시 이전 값
     private Map<String, Object> afterData;  // CREATE/UPDATE 시 이후 값
     private Map<String, Object> diff;       // UPDATE 시 변경된 필드 정보
+
+    private String beforeDataText;
+    private String afterDataText;
 }

--- a/src/main/java/com/soda/global/log/dataLog/domain/DataLogCustomRepositoryImpl.java
+++ b/src/main/java/com/soda/global/log/dataLog/domain/DataLogCustomRepositoryImpl.java
@@ -56,6 +56,17 @@ public class DataLogCustomRepositoryImpl implements DataLogCustomRepository {
         if (condition.getFrom() != null && condition.getTo() != null) {
             query.addCriteria(Criteria.where("timestamp").gte(condition.getFrom()).lte(condition.getTo()));
         }
+
+        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+            String keyword = condition.getKeyword();
+
+            Criteria operatorCriteria = Criteria.where("operator").regex(keyword, "i");
+            Criteria beforeCriteria = Criteria.where("beforeDataText").regex(keyword, "i");
+            Criteria afterCriteria = Criteria.where("afterDataText").regex(keyword, "i");
+
+            query.addCriteria(new Criteria().orOperator(operatorCriteria, beforeCriteria, afterCriteria));
+        }
+
     }
 }
 

--- a/src/main/java/com/soda/global/log/dataLog/dto/DataLogSearchRequest.java
+++ b/src/main/java/com/soda/global/log/dataLog/dto/DataLogSearchRequest.java
@@ -19,4 +19,6 @@ public class DataLogSearchRequest {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime to;
+
+    private String keyword;
 }


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 데이터 로그 키워드 검색 기능 구현

# 연관 이슈
#187 

# 확인해야할 사항
- operatorId, beforeData, afterData의 데이터를 키워드 검색할 수 있게하는 기능을 기존 로그 조회 API(GET /logs)에 추가하였습니다.
  - 검색 방법
    - GET /logs호출시 쿼리파라미터에 keyword를 함께 요청하면 operatorId, beforeData의 데이터들, afterData의 데이터들과 대조하여 keyword가 있을 시 데이터 반환됩니다.
  - 구현 방법
    - 기존에는 beforeData, afterData가 json객체(Document)의 형식으로 저장되고 있어 LIKE 검색이 불가능하였음. 따라서 데이터 로깅시 이들의 String버전인 beforeDataText, afterDataText 필드를 추가로 로깅하고 검색시 Text필드에서 검색하는 방식으로 키워드 검색을 구현하였음.
    - 몽고DB에는 LIKE검색이 없어 몽고DB Criteria의 regex를 사용하여 키워드검색을 구현하였음.
      - 인덱스를 타지 않는다는 단점이 있어 차후 성능을 고려해 몽고db의 text index를 사용한다거나 검색시 Elasticsearch를 사용하는 것을 고려해볼 수 있음.