### PR TITLE
[Refactor] 1MB 이상의 파일도 저장할 수 있게 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,11 @@ spring:
       host: ${REDIS_HOST}
       port: 6379
 
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
+
 logging:
   level:
     com.practice.simple: debug


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 1MB 이상의 파일도 저장할 수 있게 수정

# 연관 이슈
- #176 

# 확인해야할 사항
- spring servlet multipart의 max-file-size, max-request-size를 5MB로 설정하여 최대 용량을 늘림
  - 더 늘릴 수 있는데 S3의 무료 용량 제한이 5GB여서 소극적으로 5MB로 늘렸습니다. (기본 설정 1MB)