### PR TITLE
[Feature] 투표하기 기능 추가

### DIFF
--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -131,4 +131,13 @@ public class ArticleController {
         VoteViewResponse response = articleService.getVoteInfoForArticle(articleId);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
+
+    @PostMapping("/articles/{articleId}/vote/submit")
+    public ResponseEntity<ApiResponseForm<VoteSubmitResponse>> submitVote(@PathVariable Long articleId, HttpServletRequest request,
+                                                                          @Valid @RequestBody VoteSubmitRequest voteSubmitRequest) {
+        Long userId = (Long) request.getAttribute("memberId");
+        String userRole = (String) request.getAttribute("userRole").toString();
+        VoteSubmitResponse response = articleService.submitVoteForArticle(articleId, userId, userRole, voteSubmitRequest);
+        return ResponseEntity.ok(ApiResponseForm.success(response, "투표하기 성공"));
+    }
 }

--- a/src/main/java/com/soda/article/dto/article/VoteSubmitRequest.java
+++ b/src/main/java/com/soda/article/dto/article/VoteSubmitRequest.java
@@ -1,0 +1,19 @@
+package com.soda.article.dto.article;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class VoteSubmitRequest {
+
+    // 항목 선택 투표 시 선택한 항목 ID 목록 (단일 투표 시에는 크기 1)
+    private List<Long> selectedItemIds;
+
+    @Size(max = 1000, message = "답변은 최대 1000자까지 입력 가능합니다.")
+    private String textAnswer;
+
+}

--- a/src/main/java/com/soda/article/dto/article/VoteSubmitResponse.java
+++ b/src/main/java/com/soda/article/dto/article/VoteSubmitResponse.java
@@ -1,0 +1,25 @@
+package com.soda.article.dto.article;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class VoteSubmitResponse {
+
+    private Long voteId;
+    private Long voterId;
+    private Long voteAnswerId;
+    private List<Long> selectedItemIds;
+
+    public static VoteSubmitResponse from(VoteSubmitResponse response) {
+        return VoteSubmitResponse.builder()
+                .voteId(response.voteId)
+                .voterId(response.voterId)
+                .voteAnswerId(response.voteAnswerId)
+                .selectedItemIds(response.selectedItemIds)
+                .build();
+    }
+}

--- a/src/main/java/com/soda/article/error/VoteErrorCode.java
+++ b/src/main/java/com/soda/article/error/VoteErrorCode.java
@@ -11,7 +11,12 @@ public enum VoteErrorCode implements ErrorCode {
     VOTE_ALREADY_EXISTS("1305", "이미 투표가 존재합니다.", HttpStatus.BAD_REQUEST),
     VOTE_ITEM_REQUIRED("1306", "항목 선택 투표에는 최소 하나 이상의 항목이 필요합니다.", HttpStatus.BAD_REQUEST),
     VOTE_CANNOT_HAVE_BOTH_ITEMS_AND_TEXT("1307", "텍스트 답변을 허용하는 투표에는 선택 항목을 지정할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    VOTE_DUPLICATE_ITEM_TEXT("1308", "투표 항목에 중복된 내용이 포함되어 있습니다.", HttpStatus.BAD_REQUEST);;
+    VOTE_DUPLICATE_ITEM_TEXT("1308", "투표 항목에 중복된 내용이 포함되어 있습니다.", HttpStatus.BAD_REQUEST),
+    VOTE_PERMISSION_DENIED("1309", "투표를 할 권한이 없습니다", HttpStatus.FORBIDDEN),
+    INVALID_VOTE_ITEM("1310",  "선택한 항목 중 존재하지 않는 항목이 있습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_VOTED("1311", "이미 투표를 했습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_VOTE_INPUT("1312", "유효하지 않는 입력입니다." , HttpStatus.BAD_REQUEST),
+    VOTE_ITEM_NOT_FOUND("1313", "유효하지 않은 투표 항목입니다", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/article/error/VoteErrorCode.java
+++ b/src/main/java/com/soda/article/error/VoteErrorCode.java
@@ -16,7 +16,8 @@ public enum VoteErrorCode implements ErrorCode {
     INVALID_VOTE_ITEM("1310",  "선택한 항목 중 존재하지 않는 항목이 있습니다.", HttpStatus.BAD_REQUEST),
     ALREADY_VOTED("1311", "이미 투표를 했습니다.", HttpStatus.BAD_REQUEST),
     INVALID_VOTE_INPUT("1312", "유효하지 않는 입력입니다." , HttpStatus.BAD_REQUEST),
-    VOTE_ITEM_NOT_FOUND("1313", "유효하지 않은 투표 항목입니다", HttpStatus.BAD_REQUEST);
+    VOTE_ITEM_NOT_FOUND("1313", "유효하지 않은 투표 항목입니다", HttpStatus.BAD_REQUEST),
+    CANNOT_VOTE_ON_OWN_ARTICLE("1314", "작성자는 투표를 할 수 없습니다", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/article/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepositoryCustom.java
@@ -1,11 +1,15 @@
 package com.soda.article.repository;
 
 import com.querydsl.core.Tuple;
+import com.soda.article.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 public interface ArticleRepositoryCustom {
 
     Page<Tuple> findMyArticlesData(Long authorId, Long projectId, Pageable pageable);
 
+    Optional<Article> findByIdAndIsDeletedFalseWithMemberAndCompanyUsingQuerydsl(Long articleId);
 }

--- a/src/main/java/com/soda/article/repository/VoteAnswerItemRepository.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerItemRepository.java
@@ -1,0 +1,9 @@
+package com.soda.article.repository;
+
+import com.soda.article.entity.VoteAnswerItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VoteAnswerItemRepository extends JpaRepository<VoteAnswerItem, Long> {
+}

--- a/src/main/java/com/soda/article/repository/VoteAnswerRepository.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerRepository.java
@@ -1,0 +1,10 @@
+package com.soda.article.repository;
+
+import com.soda.article.entity.VoteAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VoteAnswerRepository extends JpaRepository<VoteAnswer, Long> {
+    boolean existsByVote_IdAndMember_Id(Long voteId, Long userId);
+}

--- a/src/main/java/com/soda/article/repository/VoteRepository.java
+++ b/src/main/java/com/soda/article/repository/VoteRepository.java
@@ -4,9 +4,12 @@ import com.soda.article.entity.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     boolean existsByArticleIdAndIsDeletedFalse(Long articleId);
 
+    Optional<Vote> findByIdAndIsDeletedFalse(Long voteId);
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -11,15 +11,20 @@ import com.soda.article.repository.ArticleRepository;
 import com.soda.common.link.service.LinkService;
 import com.soda.global.log.dataLog.annotation.LoggableEntityAction;
 import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
+import com.soda.member.enums.CompanyProjectRole;
 import com.soda.member.enums.MemberRole;
+import com.soda.member.service.CompanyService;
 import com.soda.member.service.MemberService;
 import com.soda.project.entity.Project;
 import com.soda.project.entity.Stage;
 import com.soda.project.error.ProjectErrorCode;
+import com.soda.project.service.CompanyProjectService;
 import com.soda.project.service.MemberProjectService;
 import com.soda.project.service.ProjectService;
 import com.soda.project.service.StageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,6 +47,7 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
     private final MemberProjectService memberProjectService;
+    private final CompanyProjectService companyProjectService;
     private final StageService stageService;
     private final ProjectService projectService;
     private final ArticleFileService articleFileService;
@@ -259,8 +265,11 @@ public class ArticleService {
      * @return 검증된 게시글
      */
     public Article validateArticle(Long articleId) {
-        return articleRepository.findByIdAndIsDeletedFalse(articleId)
-                .orElseThrow(() -> new GeneralException(ArticleErrorCode.INVALID_ARTICLE));
+        return articleRepository.findByIdAndIsDeletedFalseWithMemberAndCompanyUsingQuerydsl(articleId)
+                .orElseThrow(() -> {
+                    log.warn("유효하지 않은 게시물입니다");
+                    return new GeneralException(ArticleErrorCode.INVALID_ARTICLE);
+                });
     }
 
     /**
@@ -388,5 +397,63 @@ public class ArticleService {
 
         log.info("[ArticleService] 게시글 ID {} 투표 정보 조회 완료.", articleId);
         return VoteViewResponse.from(vote);
+    }
+
+    @Transactional
+    public VoteSubmitResponse submitVoteForArticle(Long articleId, Long userId, String userRole, VoteSubmitRequest request) {
+        log.info("[투표 제출 시작] 게시글 ID: {}, 사용자 ID: {}, 역할(문자열): {}", articleId, userId, userRole);
+        Article article = validateArticle(articleId);
+
+        Vote vote = article.getVote();
+        Long voteId = vote.getId();
+        log.debug("[투표 제출] 게시글 ID {} 에 연결된 투표 ID: {}", articleId, voteId);
+
+        Stage stage = article.getStage();
+        Project project = stage.getProject();
+
+        Member currentUser = memberService.findMemberByIdAndCompany(userId); // 로그인한 사용자 확인
+        Member author = article.getMember(); // 게시글 작성자 확인
+
+        Company currentMemberCompany = currentUser.getCompany();
+        Company authorMemberCompany = author.getCompany();
+
+        // 투표 가능한지 유효성 검사
+        CompanyProjectRole currentUserProjectRole = companyProjectService.getCompanyRoleInProject(currentMemberCompany, project);
+        CompanyProjectRole authorCompanyProjectRole = null;
+
+        if (author.getRole() != null) {
+            authorCompanyProjectRole = companyProjectService.getCompanyRoleInProject(authorMemberCompany, project);
+        } else {
+            log.info("작성자가 관리자 이므로 회사 역할 검증을 하지 않습니다.");
+        }
+        
+        checkVotingPermission(author.getRole(), currentUserProjectRole, authorCompanyProjectRole);
+
+        log.info("[투표 제출] VoteService 호출 시작 - voteId: {}, userId: {}", voteId, userId);
+        VoteSubmitResponse response = voteService.processVoteSubmit(voteId, userId, request);
+
+        return VoteSubmitResponse.from(response);
+    }
+
+    private void checkVotingPermission(MemberRole authorRole, CompanyProjectRole currentUserProjectRole, CompanyProjectRole authorCompanyProjectRole) {
+        boolean permitted = false;
+
+        // 작성자가 ADMIN > 고객사/개발사 둘 다 투표 가능
+        if (authorRole == MemberRole.ADMIN) {
+            permitted = true;
+            log.debug("[투표 권한 확인] 작성자가 ADMIN이므로 투표 허용됨.");
+        } else {
+            if (authorCompanyProjectRole == CompanyProjectRole.DEV_COMPANY && currentUserProjectRole == CompanyProjectRole.CLIENT_COMPANY) {
+                permitted = true;
+            } else if (authorCompanyProjectRole == CompanyProjectRole.CLIENT_COMPANY && currentUserProjectRole == CompanyProjectRole.DEV_COMPANY) {
+                permitted = true;
+            }
+        }
+
+        if (!permitted) {
+            log.warn("[투표 권한 없음] 작성자 회사 역할: {}, 투표자 회사 역할: {}", authorCompanyProjectRole, currentUserProjectRole);
+            throw new GeneralException(VoteErrorCode.VOTE_PERMISSION_DENIED);
+        }
+        log.debug("[투표 권한 확인 완료] 허용됨: 작성자 회사 역할({}), 투표자 회사 역할({})", authorCompanyProjectRole, currentUserProjectRole);
     }
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -414,6 +414,12 @@ public class ArticleService {
         Member currentUser = memberService.findMemberByIdAndCompany(userId); // 로그인한 사용자 확인
         Member author = article.getMember(); // 게시글 작성자 확인
 
+        // 작성자 본인 투표 금지
+        if (userId.equals(author.getId())) {
+            log.warn("작성자(ID:{})가 자신의 게시글(ID:{}) 투표에 참여하려고 시도했습니다.", userId, articleId);
+            throw new GeneralException(VoteErrorCode.CANNOT_VOTE_ON_OWN_ARTICLE);
+        }
+
         Company currentMemberCompany = currentUser.getCompany();
         Company authorMemberCompany = author.getCompany();
 

--- a/src/main/java/com/soda/article/service/VoteAnswerItemService.java
+++ b/src/main/java/com/soda/article/service/VoteAnswerItemService.java
@@ -1,0 +1,59 @@
+package com.soda.article.service;
+
+import com.soda.article.entity.Vote;
+import com.soda.article.entity.VoteAnswer;
+import com.soda.article.entity.VoteAnswerItem;
+import com.soda.article.entity.VoteItem;
+import com.soda.article.error.VoteErrorCode;
+import com.soda.article.repository.VoteAnswerItemRepository;
+import com.soda.global.response.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteAnswerItemService {
+
+    private final VoteAnswerItemRepository voteAnswerItemRepository;
+
+    @Transactional
+    public void createAndSaveVoteAnswerItems (VoteAnswer voteAnswer, List<VoteItem> selectedItems) {
+        if (CollectionUtils.isEmpty(selectedItems)) {
+            log.debug("저장할 VoteAnswerItem 이 없습니다. VoteAnswer ID: {}", voteAnswer.getId());
+            return;
+        }
+
+        Vote vote = voteAnswer.getVote();
+
+        // 단일 선택 투표인데 여러 항목을 저장하려는 경우 방지
+        if (!vote.isAllowMultipleSelection() && selectedItems.size() > 1) {
+            log.warn("단일 선택 투표(Vote ID: {})에 여러 항목({}) 저장을 시도했습니다. VoteAnswer ID: {}",
+                    vote.getId(), selectedItems.size(), voteAnswer.getId());
+            throw new GeneralException(VoteErrorCode.VOTE_MULTIPLE_SELECTION_NOT_ALLOWED);
+        }
+
+        List<VoteAnswerItem> answerItemsToSave = new ArrayList<>();
+        for (VoteItem item : selectedItems) {
+            VoteAnswerItem answerItem = VoteAnswerItem.builder()
+                    .voteResponse(voteAnswer)
+                    .voteItem(item)
+                    .build();
+            answerItemsToSave.add(answerItem);
+
+            voteAnswer.addSelectedItem(answerItem);
+        }
+
+        voteAnswerItemRepository.saveAll(answerItemsToSave);
+        log.info("VoteAnswerItem {}개 저장 완료 (VoteAnswerItemService). Answer ID: {}, Item IDs: {}",
+                answerItemsToSave.size(), voteAnswer.getId(), selectedItems.stream().map(VoteItem::getId).collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/com/soda/article/service/VoteAnswerService.java
+++ b/src/main/java/com/soda/article/service/VoteAnswerService.java
@@ -1,0 +1,59 @@
+package com.soda.article.service;
+
+import com.soda.article.entity.Vote;
+import com.soda.article.entity.VoteAnswer;
+import com.soda.article.error.VoteErrorCode;
+import com.soda.article.repository.VoteAnswerRepository;
+import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Member;
+import com.soda.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteAnswerService {
+    private final VoteAnswerRepository voteAnswerRepository;
+    private final MemberService memberService;
+
+    public boolean hasUserVoted(Long voteId, Long userId) {
+        boolean exists = voteAnswerRepository.existsByVote_IdAndMember_Id(voteId, userId);
+        log.debug("Vote ID {} 에 대한 User ID {} 의 투표 존재 여부 확인: {}", voteId, userId, exists);
+
+        return exists;
+    }
+
+    @Transactional
+    public VoteAnswer createAndSaveVoteAnswer(Vote vote, Long userId, String textAnswer) {
+        // 1. 투표 마감 여부 확인
+        if (vote.isClosed()) {
+            log.warn("Vote ID {} 는 이미 마감되었습니다.", vote.getId());
+            throw new GeneralException(VoteErrorCode.VOTE_ALREADY_CLOSED);
+        }
+
+        // 2. 텍스트 답변 허용 여부 확인
+        boolean hasText = StringUtils.hasText(textAnswer);
+        if (hasText && !vote.isAllowTextAnswer()) {
+            log.warn("Vote ID {} 는 텍스트 답변을 허용하지 않습니다.", vote.getId());
+            throw new GeneralException(VoteErrorCode.VOTE_TEXT_ANSWER_NOT_ALLOWED);
+        }
+
+        // 3. Member
+        Member member = memberService.findMemberById(userId);
+
+        VoteAnswer voteAnswer = VoteAnswer.builder()
+                .vote(vote)
+                .member(member)
+                .textAnswer(textAnswer)
+                .build();
+
+        VoteAnswer savedAnswer = voteAnswerRepository.save(voteAnswer);
+        log.info("VoteAnswer 저장 완료 (VoteAnswerService). Answer ID: {}", savedAnswer.getId());
+        return savedAnswer;
+    }
+}

--- a/src/main/java/com/soda/article/service/VoteItemService.java
+++ b/src/main/java/com/soda/article/service/VoteItemService.java
@@ -2,13 +2,16 @@ package com.soda.article.service;
 
 import com.soda.article.entity.Vote;
 import com.soda.article.entity.VoteItem;
+import com.soda.article.error.VoteErrorCode;
 import com.soda.article.repository.VoteItemRepository;
+import com.soda.global.response.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,6 +51,22 @@ public class VoteItemService {
 
         log.info("VoteItem 생성 및 저장 완료: voteId={}, savedCount={}", vote.getId(), savedVoteItems.size());
         return savedVoteItems;
+    }
+
+    public List<VoteItem> findVoteItemsByIds(List<Long> itemIds) {
+        if (CollectionUtils.isEmpty(itemIds)) {
+            return new ArrayList<>();
+        }
+        List<VoteItem> foundItems = voteItemRepository.findAllById(itemIds);
+
+        if (foundItems.size() != itemIds.size()) {
+            log.warn("요청된 VoteItem ID 목록에 존재하지 않는 ID가 포함되어 있습니다. Requested: {}, Found count: {}",
+                    itemIds, foundItems.size());
+            throw new GeneralException(VoteErrorCode.INVALID_VOTE_ITEM);
+        }
+        log.debug("VoteItem {}개 조회 완료 (VoteItemService). IDs: {}", foundItems.size(), itemIds);
+
+        return foundItems;
     }
 
 }

--- a/src/main/java/com/soda/member/repository/MemberRepository.java
+++ b/src/main/java/com/soda/member/repository/MemberRepository.java
@@ -46,4 +46,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "OR (c.name IS NOT NULL AND LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     Page<Member> findByKeywordIncludingDeleted(@Param("keyword") String keyword, Pageable pageable);
 
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.company WHERE m.id = :memberId")
+    Optional<Member> findByIdWithCompany(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -250,4 +250,13 @@ public class MemberService {
 
         memberRepository.save(member);
     }
+
+    public Member findMemberByIdAndCompany(Long userId) {
+        log.debug("Fetching Member with Company using Fetch Join. User ID: {}", userId);
+        return memberRepository.findByIdWithCompany(userId)
+                .orElseThrow(() -> {
+                    log.warn("Member not found with ID: {}", userId);
+                    return new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
+                });
+    }
 }


### PR DESCRIPTION
# 요약

투표하기 기능

# 연관 이슈
#170 

# 확인 사항
### 1. 투표할 때 유효성 검사
- 중복 투표 불가능
- ADMIN이 작성한 경우 : 고객사/개발사 전부 투표 가능
- 고객사 직원이 작성한 경우 : 개발사만 투표 가능
- 개발사 직원이 작성한 경우 : 고객사만 투표 가능
### 2. 게시글 유효성 검사 메서드 > QueryDSL에 추가
- 기존에는 `findByIdAndIsDeletedFalse` 메서드로 게시글 유효성 검사를 했었습니다.
- 그러나 게시글 조회 시 연관된 Member와 Company 정보를 함께 효율적으로 가져오기 위해`findByIdAndIsDeletedFalseWithMemberAndCompanyUsingQuerydsl` 메서드를 추가하여 적용했습니다.
### 3. 다중선택/단일선택/텍스트 유형별 검사
- 다중선택 : 리스트 형식으로 여러 항목을 선택할 수 있습니다.
- 단일선택: 리스트 size 1로 제한하여 하나만 선택할 수 있습니다.
- 텍스트 입력 : 텍스트 입력을 할 수 있습니다.
### 4. memberService `findMemberByIdAndCompany` 추가
- 멤버 조회 시 연관된 Company 정보를 효율적으로 가져오기 위해 쿼리문을 작성했습니다.
- 추후 querydsl로 리팩토링하면 좋을 듯 합니다.


close #170 