### PR TITLE
[Feature] 게시글 투표 결과 조회 기능

### DIFF
--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -148,4 +148,11 @@ public class ArticleController {
         VoteItemAddResponse response = articleService.addVoteItem(articleId, userId, voteItemAddRequest);
         return ResponseEntity.ok(ApiResponseForm.success(response, "투표 항목 추가 성공"));
     }
+
+    @GetMapping("/articles/{articleId}/vote/results")
+    public ResponseEntity<ApiResponseForm<VoteResultResponse>> getVoteResults(@PathVariable Long articleId, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute("memberId");
+        VoteResultResponse response = articleService.getVoteResults(articleId, userId);
+        return ResponseEntity.ok(ApiResponseForm.success(response));
+    }
 }

--- a/src/main/java/com/soda/article/controller/ArticleController.java
+++ b/src/main/java/com/soda/article/controller/ArticleController.java
@@ -2,7 +2,6 @@ package com.soda.article.controller;
 
 import com.soda.article.dto.article.*;
 import com.soda.article.service.ArticleService;
-import com.soda.article.service.VoteService;
 import com.soda.common.file.dto.FileDeleteResponse;
 import com.soda.common.file.dto.FileUploadResponse;
 import com.soda.common.file.service.FileService;
@@ -27,7 +26,6 @@ public class ArticleController {
     private final ArticleService articleService;
     private final FileService fileService;
     private final LinkService linkService;
-    private final VoteService voteService;
 
     @PostMapping("/articles")
     public ResponseEntity<ApiResponseForm<ArticleCreateResponse>> createArticle(@RequestBody ArticleCreateRequest request, HttpServletRequest user) {
@@ -132,7 +130,7 @@ public class ArticleController {
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 
-    @PostMapping("/articles/{articleId}/vote/submit")
+    @PostMapping("/articles/{articleId}/vote/submission")
     public ResponseEntity<ApiResponseForm<VoteSubmitResponse>> submitVote(@PathVariable Long articleId, HttpServletRequest request,
                                                                           @Valid @RequestBody VoteSubmitRequest voteSubmitRequest) {
         Long userId = (Long) request.getAttribute("memberId");
@@ -149,7 +147,7 @@ public class ArticleController {
         return ResponseEntity.ok(ApiResponseForm.success(response, "투표 항목 추가 성공"));
     }
 
-    @GetMapping("/articles/{articleId}/vote/results")
+    @GetMapping("/articles/{articleId}/vote-results")
     public ResponseEntity<ApiResponseForm<VoteResultResponse>> getVoteResults(@PathVariable Long articleId, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("memberId");
         VoteResultResponse response = articleService.getVoteResults(articleId, userId);

--- a/src/main/java/com/soda/article/dto/article/VoteResultResponse.java
+++ b/src/main/java/com/soda/article/dto/article/VoteResultResponse.java
@@ -1,0 +1,68 @@
+package com.soda.article.dto.article;
+
+import com.soda.article.entity.Vote;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class VoteResultResponse {
+
+    private Long voteId;
+    private String title;
+    private boolean allowMultipleSelection;
+    private boolean allowTextAnswer;
+    private LocalDateTime deadLine;
+    private boolean isClosed;
+    private int totalParticipants;
+    private List<ItemResultDTO> itemResults;
+    private List<String> textAnswers;
+
+    @Getter
+    @Builder
+    public static class ItemResultDTO {
+        private Long itemId;
+        private String itemText;
+        private int count;
+        private double percentage;
+    }
+
+    public static VoteResultResponse from(Vote vote, int totalParticipants, Map<Long, Long> itemCounts, List<String> textAnswers) {
+        boolean closed = vote.isClosed();
+        List<ItemResultDTO> itemResultDTOs = null;
+
+        if (!vote.isAllowTextAnswer() && vote.getVoteItems() != null) {
+            final int effectiveTotalParticipants = totalParticipants > 0 ? totalParticipants : 1;
+            itemResultDTOs = vote.getVoteItems().stream()
+                    .filter(item -> !item.getIsDeleted())
+                    .map(item -> {
+                        long count = itemCounts.getOrDefault(item.getId(), 0L);
+                        // 퍼센트 계산 시 분모가 0이 아닌지 확인
+                        double percentage = (totalParticipants > 0) ? ((double) count / totalParticipants) * 100 : 0;
+                        return ItemResultDTO.builder()
+                                .itemId(item.getId())
+                                .itemText(item.getText())
+                                .count((int) count)
+                                .percentage(Math.round(percentage * 10.0) / 10.0) // 소수점 첫째 자리
+                                .build();
+                    })
+                    .toList();
+        }
+
+        return VoteResultResponse.builder()
+                .voteId(vote.getId())
+                .title(vote.getTitle())
+                .allowMultipleSelection(vote.isAllowMultipleSelection())
+                .allowTextAnswer(vote.isAllowTextAnswer())
+                .deadLine(vote.getDeadLine())
+                .isClosed(closed)
+                .totalParticipants(totalParticipants)
+                .itemResults(itemResultDTOs)
+                .textAnswers(textAnswers)
+                .build();
+    }
+}

--- a/src/main/java/com/soda/article/repository/VoteAnswerItemRepository.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerItemRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface VoteAnswerItemRepository extends JpaRepository<VoteAnswerItem, Long> {
+public interface VoteAnswerItemRepository extends JpaRepository<VoteAnswerItem, Long>, VoteAnswerItemRepositoryCustom {
 }

--- a/src/main/java/com/soda/article/repository/VoteAnswerItemRepositoryCustom.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerItemRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.soda.article.repository;
+
+import java.util.Map;
+
+public interface VoteAnswerItemRepositoryCustom {
+
+    Map<Long, Long> countItemGroupByVoteItemId(Long voteId);
+}

--- a/src/main/java/com/soda/article/repository/VoteAnswerItemRepositoryImpl.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerItemRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.soda.article.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.soda.article.entity.QVoteAnswer.voteAnswer;
+import static com.soda.article.entity.QVoteAnswerItem.voteAnswerItem;
+
+@Repository
+@RequiredArgsConstructor
+public class VoteAnswerItemRepositoryImpl implements VoteAnswerItemRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, Long> countItemGroupByVoteItemId(Long voteId) {
+        List<Tuple> results = queryFactory
+                .select(
+                        voteAnswerItem.voteItem.id,
+                        voteAnswerItem.id.count()
+                )
+                .from(voteAnswerItem)
+                .join(voteAnswerItem.voteResponse, voteAnswer)
+                .where(
+                        voteAnswer.vote.id.eq(voteId)
+                )
+                .groupBy(voteAnswerItem.voteItem.id)
+                .fetch();
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(voteAnswerItem.voteItem.id),
+                        tuple -> Optional.ofNullable(tuple.get(voteAnswerItem.id.count())).orElse(0L)
+                ));
+    }
+}

--- a/src/main/java/com/soda/article/repository/VoteAnswerRepository.java
+++ b/src/main/java/com/soda/article/repository/VoteAnswerRepository.java
@@ -1,10 +1,17 @@
 package com.soda.article.repository;
 
+import com.soda.article.entity.Vote;
 import com.soda.article.entity.VoteAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface VoteAnswerRepository extends JpaRepository<VoteAnswer, Long> {
     boolean existsByVote_IdAndMember_Id(Long voteId, Long userId);
+
+    int countByVote(Vote vote);
+
+    List<VoteAnswer> findByVote(Vote vote);
 }

--- a/src/main/java/com/soda/article/service/ArticleService.java
+++ b/src/main/java/com/soda/article/service/ArticleService.java
@@ -5,7 +5,6 @@ import com.soda.article.dto.article.*;
 import com.soda.article.entity.Article;
 import com.soda.article.entity.ArticleLink;
 import com.soda.article.entity.Vote;
-import com.soda.article.entity.VoteItem;
 import com.soda.article.error.ArticleErrorCode;
 import com.soda.article.error.VoteErrorCode;
 import com.soda.article.repository.ArticleRepository;
@@ -16,7 +15,6 @@ import com.soda.member.entity.Company;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.CompanyProjectRole;
 import com.soda.member.enums.MemberRole;
-import com.soda.member.service.CompanyService;
 import com.soda.member.service.MemberService;
 import com.soda.project.entity.Project;
 import com.soda.project.entity.Stage;
@@ -25,7 +23,6 @@ import com.soda.project.service.CompanyProjectService;
 import com.soda.project.service.MemberProjectService;
 import com.soda.project.service.ProjectService;
 import com.soda.project.service.StageService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -531,5 +528,18 @@ public class ArticleService {
         }
 
         log.debug("항목 추가 권한 확인 완료 (교차 회사 역할): Author Role({}), Requester Role({})", authorRole, requesterRole);
+    }
+
+    public VoteResultResponse getVoteResults(Long articleId, Long userId) {
+        log.info("[결과 조회 시작(ArticleService) - 조건 없음/빌더 사용] Article ID: {}, User ID: {}", articleId, userId);
+
+        Article article = validateArticle(articleId);
+        Vote vote = article.getVote();
+        log.debug("게시글 및 투표 정보 확인 완료. Vote ID: {}", vote.getId());
+
+        VoteResultResponse response = voteService.getVoteResultData(vote);
+
+        log.info("[결과 조회 성공(ArticleService)] Article ID: {}, Vote ID: {}", articleId, response.getVoteId());
+        return response;
     }
 }

--- a/src/main/java/com/soda/article/service/VoteAnswerItemService.java
+++ b/src/main/java/com/soda/article/service/VoteAnswerItemService.java
@@ -15,6 +15,7 @@ import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -56,4 +57,12 @@ public class VoteAnswerItemService {
         log.info("VoteAnswerItem {}개 저장 완료 (VoteAnswerItemService). Answer ID: {}, Item IDs: {}",
                 answerItemsToSave.size(), voteAnswer.getId(), selectedItems.stream().map(VoteItem::getId).collect(Collectors.toList()));
     }
+
+    // 특정 투표의 특정 항목별 득표 수
+    public Map<Long, Long> countItemsByVote(Long voteId) {
+        Map<Long, Long> counts = voteAnswerItemRepository.countItemGroupByVoteItemId(voteId);
+        log.debug("Vote ID {} 항목별 활성 답변 집계 (VoteAnswerItemService): {}", voteId, counts);
+        return counts;
+    }
+
 }

--- a/src/main/java/com/soda/article/service/VoteAnswerService.java
+++ b/src/main/java/com/soda/article/service/VoteAnswerService.java
@@ -7,11 +7,15 @@ import com.soda.article.repository.VoteAnswerRepository;
 import com.soda.global.response.GeneralException;
 import com.soda.member.entity.Member;
 import com.soda.member.service.MemberService;
+import io.netty.util.internal.StringUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -55,5 +59,23 @@ public class VoteAnswerService {
         VoteAnswer savedAnswer = voteAnswerRepository.save(voteAnswer);
         log.info("VoteAnswer 저장 완료 (VoteAnswerService). Answer ID: {}", savedAnswer.getId());
         return savedAnswer;
+    }
+
+    // 특정 투표에 대한 답변 수
+    public int countAnswers(Vote vote) {
+        int count = voteAnswerRepository.countByVote(vote);
+        log.debug("Vote ID {} 활성 답변 수 조회 (VoteAnswerService): {}", vote.getId(), count);
+        return count;
+    }
+
+    // 특정 투표에 대한 텍스트 답변 목록
+    public List<String> findTextAnswers(Vote vote) {
+        List<VoteAnswer> answers = voteAnswerRepository.findByVote(vote);
+        List<String> textAnswers = answers.stream()
+                .map(VoteAnswer::getTextAnswer)
+                .filter(StringUtils::hasText)
+                .toList();
+        log.debug("Vote ID {} 활성 텍스트 답변 조회 (VoteAnswerService): {} 개", vote.getId(), textAnswers.size());
+        return textAnswers;
     }
 }


### PR DESCRIPTION

# 요약

사용자는 투표 ID를 통해 해당 투표의 총 참여자 수, 항목별 득표 수 및 비율(항목 선택형 투표의 경우), 또는 제출된 텍스트 답변 목록(텍스트 답변형 투표의 경우)을 확인할 수 있습니다.

# 연관 이슈
#201 


# 확인 사항
### response에서 percentage 계산하는 메서드 추가
- 투표율을 계산하기 위해 추가했는데, 만약 필요가 없다고 판단되면 삭제해도 됩니다.
### queryDSL문 추가
- 항목별 득표 수를 효율적으로 집계하기 위해 QueryDSL을 사용한 Custom Repository 로직을 구현했습니다.
- countItemGroupByVoteItemId(Long voteId): 특정 투표 ID에 대해 VoteAnswerItem을 voteItem.id 기준으로 그룹화하고 개수를 세어 Map<Long, Long> 형태로 반환합니다.
### 투표 결과 조회를 위한 메서드
- `VoteAnswerService`
   - `countAnswers`: 특정 투표(Vote)에 대한 총 답변 수를 조회하는 메서드
   - `findTextAnswers`: 특정 투표(Vote)에 대한 모든 텍스트 답변 목록을 조회하는 메서드
- `VoteAnswerItemService`
   - `countItemsByVote`: 특정 투표 ID에 대해 각 투표 항목(VoteItem)별 득표 수를 집계하는 메서드
### swagger 테스트 시 결과 예시
```{
  "status": "success",
  "code": "200",
  "message": "OK",
  "data": {
    "voteId": 2,
    "title": "점심 메뉴 선택 (하나만!)",
    "allowMultipleSelection": false,
    "allowTextAnswer": false,
    "deadLine": null,
    "totalParticipants": 2,
    "itemResults": [
      {
        "itemId": 4,
        "itemText": "김치찌개",
        "count": 2,
        "percentage": 100
      },
      {
        "itemId": 5,
        "itemText": "된장찌개",
        "count": 0,
        "percentage": 0
      },
      {
        "itemId": 6,
        "itemText": "부대찌개",
        "count": 0,
        "percentage": 0
      },
      {
        "itemId": 7,
        "itemText": "item text example",
        "count": 0,
        "percentage": 0
      },
      {
        "itemId": 8,
        "itemText": "item text example22",
        "count": 0,
        "percentage": 0
      }
    ],
    "textAnswers": [],
    "closed": false
  }
}

```

Closed #201 