### PR TITLE
[Feature] 프로젝트 제목으로 검색 기능 추가

### DIFF
--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -48,11 +48,11 @@ public class ProjectController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<ApiResponseForm<Page<MyProjectListResponse>>> getMyProjects(HttpServletRequest request,
+    public ResponseEntity<ApiResponseForm<Page<MyProjectListResponse>>> getMyProjects(@ModelAttribute ProjectSearchCondition projectSearchCondition,  HttpServletRequest request,
                                                                                     @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Long userId = (Long) request.getAttribute("memberId");
         String userRole = (String) request.getAttribute("userRole").toString();
-        Page<MyProjectListResponse> response = projectService.getMyProjects(userId, userRole, pageable);
+        Page<MyProjectListResponse> response = projectService.getMyProjects(projectSearchCondition, userId, userRole, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(response));
     }
 

--- a/src/main/java/com/soda/project/controller/ProjectController.java
+++ b/src/main/java/com/soda/project/controller/ProjectController.java
@@ -41,9 +41,9 @@ public class ProjectController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ApiResponseForm<Page<ProjectListResponse>>> getAllProjects(@RequestParam(required = false) ProjectStatus status,
+    public ResponseEntity<ApiResponseForm<Page<ProjectListResponse>>> getAllProjects(@ModelAttribute ProjectSearchCondition projectSearchCondition,
                                                                                      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<ProjectListResponse> projectList = projectService.getAllProjects(status, pageable);
+        Page<ProjectListResponse> projectList = projectService.getAllProjects(projectSearchCondition, pageable);
         return ResponseEntity.ok(ApiResponseForm.success(projectList));
     }
 

--- a/src/main/java/com/soda/project/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/soda/project/dto/ProjectSearchCondition.java
@@ -1,0 +1,16 @@
+package com.soda.project.dto;
+
+import com.soda.project.enums.ProjectStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectSearchCondition {
+
+    private ProjectStatus status;
+    private String keyword;
+
+}

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
@@ -7,9 +7,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProjectRepositoryCustom {
-    Page<Tuple> findMyProjectsData(Long memberId, Pageable pageable);
+    Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable);
 
     Page<Tuple> findMyCompanyProjectsData(Long memberId, Long companyId, Pageable pageable);
 
     Page<Project> searchProjects(ProjectSearchCondition request, Pageable pageable);
+
 }

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.soda.project.repository;
 
 import com.querydsl.core.Tuple;
+import com.soda.project.dto.ProjectSearchCondition;
+import com.soda.project.entity.Project;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +10,6 @@ public interface ProjectRepositoryCustom {
     Page<Tuple> findMyProjectsData(Long memberId, Pageable pageable);
 
     Page<Tuple> findMyCompanyProjectsData(Long memberId, Long companyId, Pageable pageable);
+
+    Page<Project> searchProjects(ProjectSearchCondition request, Pageable pageable);
 }

--- a/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/repository/ProjectRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     private static final QCompanyProject companyProject = QCompanyProject.companyProject;
 
     @Override
-    public Page<Tuple> findMyProjectsData(Long memberId, Pageable pageable) {
+    public Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable) {
         List<Tuple> content = queryFactory
                 .select(
                         project,
@@ -49,7 +49,9 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                         memberProject.member.id.eq(memberId),
                         project.isDeleted.isFalse(),
                         memberProject.isDeleted.isFalse(),
-                        companyProject.isDeleted.isFalse() // 회사 연결도 활성 상태
+                        companyProject.isDeleted.isFalse(), // 회사 연결도 활성 상태
+                        statusEq(projectSearchCondition.getStatus()),
+                        titleContains(projectSearchCondition.getKeyword())
                 )
                 .orderBy(project.createdAt.desc())
                 .offset(pageable.getOffset())
@@ -67,7 +69,9 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                         memberProject.member.id.eq(memberId),
                         project.isDeleted.isFalse(),
                         memberProject.isDeleted.isFalse(),
-                        companyProject.isDeleted.isFalse()
+                        companyProject.isDeleted.isFalse(),
+                        statusEq(projectSearchCondition.getStatus()),
+                        titleContains(projectSearchCondition.getKeyword())
                 );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -119,24 +119,13 @@ public class ProjectService {
     /**
      * 전체 프로젝트 목록 조회하는 메서드
      * 프로젝트 상태에 따라 필터링해서 반환할 수 있음
-     * @param status 필터링할 프로젝트 상태 (만약 null일 경우 전체 프로젝트 반환)
      * @return ProjectListResponse 형식으로 프로젝트 목록 반환
      */
-    public Page<ProjectListResponse> getAllProjects(ProjectStatus status, Pageable pageable) {
-        log.info("전체 프로젝트 조회 시작: 상태 = {}, 페이지 번호 = {}, 페이지 크기 = {}",
-                status != null ? status : "전체",
-                pageable.getPageNumber(),
-                pageable.getPageSize());
+    public Page<ProjectListResponse> getAllProjects(ProjectSearchCondition projectSearchCondition, Pageable pageable) {
 
-        Page<Project> projectList;
+        Page<Project> projectList = projectRepository.searchProjects(projectSearchCondition, pageable);
 
-        if (status != null) {
-            projectList = projectRepository.findByStatusAndIsDeletedFalse(status, pageable);
-        } else {
-            projectList = projectRepository.findByIsDeletedFalse(pageable);
-        }
-
-        log.info("프로젝트 조회 완료: 조회된 페이지 크기 = {}, 총 프로젝트 수 = {}",
+        log.info("프로젝트 검색/조회 완료: 조회된 페이지 크기 = {}, 총 프로젝트 수 = {}",
                 projectList.getSize(),
                 projectList.getTotalElements());
 

--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -140,7 +140,7 @@ public class ProjectService {
      * @param pageable 페이지네이션
      * @return ProjectListResponse 형식으로 참여 중 프로젝트 목록 반환
      */
-    public Page<MyProjectListResponse> getMyProjects(Long userId, String userRole, Pageable pageable) {
+    public Page<MyProjectListResponse> getMyProjects(ProjectSearchCondition projectSearchCondition, Long userId, String userRole, Pageable pageable) {
         log.info("사용자 프로젝트 조회 시작: 사용자 ID = {}, 사용자 역할 = {}", userId, userRole);
 
         if (!USER_ROLE.equals(userRole)) {
@@ -148,7 +148,7 @@ public class ProjectService {
             return Page.empty(pageable);
         }
 
-        Page<Tuple> tuplePage = projectRepository.findMyProjectsData(userId, pageable);
+        Page<Tuple> tuplePage = projectRepository.findMyProjectsData(projectSearchCondition, userId, pageable);
         if (tuplePage.isEmpty()) {
             log.info("사용자 ID {}가 참여한 프로젝트가 없습니다. 빈 페이지 반환.", userId);
         } else {


### PR DESCRIPTION
# 요약

기존에 있던 프로젝트 목록 전체 조회 API에 검색 기능 추가했습니다.
사용자의 프로젝트 목록 조회 API에 검색 기능 / 상태 별 필터링 기능 추가했습니다

# 연관 이슈
#184 


# 확인 사항
### 1. `ProjectSearchCondition` 생성
- `@ModelAttribute`로 한번에 파일로 받아서 검색 또는 필터링 하기 위해 새로 생성하였습니다.
- status 별로 조회하거나, keyword로 검색하도록 하였습니다.
### 2. `ProjectRepositoryImpl`에 프로젝트명으로 검색하는 메서드 추가
### 3. 프로젝트 목록 조회 / 사용자의 프로젝트 목록 조회 API 수정
- status를 추가하는 경우 필터링해서 조회하는 기능을 추가했습니다.
- 그 외에 keyword를 추가하여 프로젝트 제목으로 검색하는 기능을 추가했습니다.


Close #184 