### PR TITLE
[Feat] 멤버id 기반 승인요청 조회시 projectId도 반환되도록 수정

### DIFF
--- a/src/main/java/com/soda/request/dto/request/RequestDTO.java
+++ b/src/main/java/com/soda/request/dto/request/RequestDTO.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 @Getter
 public class RequestDTO {
     private Long requestId;
+    private Long projectId;
     private Long stageId;
     private Long memberId;
     private String memberName;
@@ -32,6 +33,7 @@ public class RequestDTO {
     public static RequestDTO fromEntity(Request request) {
         return RequestDTO.builder()
                 .requestId(request.getId())
+                .projectId(request.getStage().getProject().getId())
                 .stageId(request.getStage().getId())
                 .memberId(request.getMember().getId())
                 .memberName(request.getMember().getName())


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 멤버id 기반 승인요청 조회시 projectId도 반환되도록 수정

# 연관 이슈
#216 

# 확인해야할 사항
- 승인요청 페이지네이션 조회 API의 RequestDTO에 projectId 필드를 추가하는 방식으로 구현하였습니다