### PR TITLE
[Feature] SseEmitter 관리 서비스 구현

### DIFF
--- a/src/main/java/com/soda/notice/service/EmitterService.java
+++ b/src/main/java/com/soda/notice/service/EmitterService.java
@@ -1,0 +1,68 @@
+package com.soda.notice.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SseEmitter 객체를 중앙에서 관리하는 서비스
+ * 사용자 ID를 키로 사용하여 Emitter를 저장, 조회, 삭제합니다.
+ */
+@Service
+@Slf4j
+public class EmitterService {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * 지정된 사용자 ID에 대한 SseEmitter를 저장합니다.
+     *
+     * @param userId 사용자 ID
+     * @param emitter 저장할 SseEmitter 객체
+     */
+    public void addEmitter(Long userId, SseEmitter emitter) {
+        this.emitters.put(userId, emitter);
+        log.info("Emitter added for user ID: {}. Current emitter count: {}", userId, emitters.size());
+    }
+
+    /**
+     * 지정된 사용자 ID에 해당하는 SseEmitter를 제거합니다.
+     *
+     * @param userId 사용자 ID
+     */
+    public void removeEmitter(Long userId) {
+        SseEmitter removedEmitter = this.emitters.remove(userId);
+        if (removedEmitter != null) {
+            log.info("Emitter removed successfully for user ID: {}. Current emitter count: {}", userId, emitters.size());
+        } else {
+            log.warn("Emitter not found for removal for user ID: {}", userId);
+        }
+    }
+
+    /**
+     * 지정된 사용자 ID에 해당하는 SseEmitter를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 해당 사용자의 SseEmitter Optional 객체 (없으면 Optional.empty())
+     */
+    public Optional<SseEmitter> getEmitter(Long userId) {
+        return Optional.ofNullable(this.emitters.get(userId));
+    }
+
+    /**
+     * (Optional) 현재 활성화된 모든 Emitter 맵의 불변 뷰를 반환합니다.
+     * Heartbeat 등 전체 Emitter에 대한 작업 시 사용될 수 있습니다.
+     * 주의: 반환된 맵은 수정할 수 없습니다.
+     *
+     * @return 사용자 ID를 키로, SseEmitter를 값으로 가지는 불변 맵
+     */
+    public Map<Long, SseEmitter> getAllEmitters() {
+        return Collections.unmodifiableMap(this.emitters);
+    }
+
+}


### PR DESCRIPTION
# 요약

<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
실시간 사용자 알림 기능 구현의 일환으로 Server-Sent Events (SSE) 기술을 선택했습니다.
SSE는 서버에서 클라이언트로의 단방향 데이터 푸시에 효율적이며,
웹소켓에 비해 구현이 비교적 간단하다는 장점이 있어 실시간 알림에 적합하다고 판단했습니다.

실시간 알림을 위한 SSE(Server-Sent Events) 연결을 관리하는 `EmitterService`를 구현합니다.

-   **EmitterService 구현:**
    -   사용자 ID를 키로 `SseEmitter` 객체를 `ConcurrentHashMap`에 저장 및 관리합니다.
    -   주요 기능: Emitter 추가, 제거, 조회 기능
-   **목적:** 향후 알림 발생 시, 이 서비스를 통해 특정 사용자의 Emitter를 찾아 실시간 알림을 전송합니다.
-   **참고:** 본 PR은 서비스 구현만 포함하며, 실제 사용 로직은 후속 작업(#179 이후)에서 진행됩니다.

# 연관 이슈

Close #179

# Pull Request 체크리스트

## TODO

-   [x] 최종 결과물을 확인했는가?
-   [x] 의미 있는 커밋 메시지를 작성했는가?