### PR TITLE
[Fix] 고객사/개발사 멤버 제대로 추가 안되는 버그 수정

### DIFF
--- a/src/main/java/com/soda/project/error/ProjectErrorCode.java
+++ b/src/main/java/com/soda/project/error/ProjectErrorCode.java
@@ -15,7 +15,8 @@ public enum ProjectErrorCode implements ErrorCode {
     NO_PERMISSION_TO_UPDATE_STATUS("1009", "Unauthorized: You do not have permission to update the project status.", HttpStatus.FORBIDDEN),
     MEMBER_LIST_EMPTY("1010", "Either manager or participant member list must be provided.", HttpStatus.NOT_FOUND),
     MEMBER_NOT_IN_SPECIFIED_COMPANY ("1011", "One or more requested members do not belong to the specified company.", HttpStatus.BAD_REQUEST),
-    MEMBER_PROJECT_NOT_FOUND("1012", "Invalid member project", HttpStatus.NOT_FOUND);
+    MEMBER_PROJECT_NOT_FOUND("1012", "Invalid member project", HttpStatus.NOT_FOUND),
+    NOT_NULL("1013", "프로젝트, 회사, 역할은 null일 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
+++ b/src/main/java/com/soda/project/repository/CompanyProjectRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 
 @Repository
 public interface CompanyProjectRepository extends JpaRepository<CompanyProject, Long> {
-    boolean existsByCompanyAndProject(Company company, Project project);
-
     List<CompanyProject> findByProject(Project project);
 
     Optional<CompanyProject> findByCompanyAndProjectAndIsDeletedFalse(Company company, Project project);

--- a/src/main/java/com/soda/project/service/CompanyProjectService.java
+++ b/src/main/java/com/soda/project/service/CompanyProjectService.java
@@ -25,19 +25,25 @@ public class CompanyProjectService {
     private final CompanyProjectRepository companyProjectRepository;
 
     public void assignCompanyToProject(Company company, Project project, CompanyProjectRole role) {
-        if (!company.getIsDeleted() && !companyProjectRepository.existsByCompanyAndProject(company, project)) {
-            CompanyProjectDTO companyProjectDTO = CompanyProjectDTO.builder()
-                    .companyId(company.getId())
-                    .projectId(project.getId())
-                    .companyProjectRole(role)
-                    .build();
-
-            // DTO -> Entity
-            CompanyProject companyProject = companyProjectDTO.toEntity(company, project, role);
-
-            // 데이터베이스에 회사-프로젝트 관계 저장
-            companyProjectRepository.save(companyProject);
+        // 입력 값 Null 체크 (최소한의 방어)
+        if (company == null || project == null || role == null) {
+            log.error("assignCompanyToProject 호출 오류: company, project, role 중 null 값 존재");
+            throw new GeneralException(ProjectErrorCode.NOT_NULL);
         }
+
+        log.info(">>> 회사-프로젝트 연결 생성 시작: Company ID={}, Project ID={}, Target Role={}",
+                company.getId(), project.getId(), role);
+
+        CompanyProject companyProject = CompanyProject.builder()
+                .company(company)
+                .project(project)
+                .companyProjectRole(role)
+                .build();
+
+        CompanyProject savedEntry = companyProjectRepository.save(companyProject);
+
+        log.info("회사-프로젝트 연결 생성 완료: Company ID={}, Project ID={}", company.getId(), project.getId());
+        log.info("회사-프로젝트 연결/업데이트 완료: Company ID={}, Project ID={}", company.getId(), project.getId());
     }
 
     public List<Company> getCompaniesByRole(Project project, CompanyProjectRole role) {


### PR DESCRIPTION

# 요약
고객사/개발사 멤버 제대로 추가 안되는 버그 수정

# 연관 이슈
#228 


# 확인 사항
- 프로젝트에 새로운 회사/멤버 추가하는 API 테스트 시, DB에 제대로 저장이 되지 않는데 200 OK가 되는 오류가 발생했습니다.
- 기존에는 DB에 이미 존재하는지 여부를 확인하고 삭제된 회사/멤버를 재할당하거나 role을 변경해주는 조건이 있었는데 삭제했습니다.
- 프로젝트에 회사/멤버를 새로 할당하고 저장되도록 조건들을 삭제해주었습니다.