### PR TITLE
[Feature] 프로젝트 상태 진행중으로 변경 로직 추가

### DIFF
--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -112,6 +112,17 @@ public class ProjectService {
 
         log.info("개발사 지정 완료: 프로젝트 ID = {}", projectId);
 
+        // CONTRACT > IN_PROGRESS 로 상태 변경
+        if (project.getStatus() == ProjectStatus.CONTRACT) {
+            log.info("프로젝트 상태 변경 시도: ID={}, 현재 상태={}, 변경 상태={}",
+                    projectId, project.getStatus(), ProjectStatus.IN_PROGRESS);
+            project.changeStatus(ProjectStatus.IN_PROGRESS);
+        } else {
+            log.info("프로젝트 상태 변경 건너뜀: ID={}, 현재 상태={}", projectId, project.getStatus());
+        }
+
+        log.info("개발사 지정 전체 프로세스 완료: 프로젝트 ID = {}", projectId);
+
         // response 생성
         return createDevCompanyAssignmentResponse(project);
     }


### PR DESCRIPTION

# 요약
프로젝트 상태 진행중으로 변경 로직 추가

# 연관 이슈
#231 


# 확인 사항
- 개발사 지정 시, [계약중] 상태에서 [진행중] 상태로 변경되는 로직을 추가하였습니다.
- `/projects/{projectId}/dev-companies` 는 처음에 개발사가 없는 프로젝트에 개발사를 추가할 때만 사용되는 API입니다.
- 따라서 개발사 지정 시 해당 프로젝트가 [진행중] 이라고 생각하여 자동으로 상태를 변경하도록 했습니다.
- 그 이후에는 각 프로젝트의 담당자들 또는 관리자가 직접 프로젝트 상태 관리를 할 수 있습니다.

Closed #231 