### PR TITLE
[Feature] SSE Emitter 관리 및 구독 로직 개선

### DIFF
--- a/src/main/java/com/soda/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/soda/global/security/config/SecurityConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
+import jakarta.servlet.DispatcherType;
 import java.util.List;
 
 /**
@@ -60,9 +60,11 @@ public class SecurityConfig {
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+                .securityMatcher(request -> request.getDispatcherType().equals(DispatcherType.REQUEST))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .exceptionHandling(AbstractHttpConfigurer::disable)
+                .addFilterBefore(jwtExceptionFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorize -> {
                     List<String> excludedPaths = securityProperties.getExcludedPaths();
                     if (excludedPaths != null && !excludedPaths.isEmpty()) {
@@ -70,10 +72,9 @@ public class SecurityConfig {
                     }
                     authorize.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
                     authorize.anyRequest().authenticated();
-                })
+                });
 
-                .addFilterBefore(jwtExceptionFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/com/soda/notice/controller/NoticeController.java
+++ b/src/main/java/com/soda/notice/controller/NoticeController.java
@@ -1,16 +1,25 @@
 package com.soda.notice.controller;
 
+import com.soda.global.security.auth.UserDetailsImpl; // UserDetailsImpl import 확인
+import com.soda.notice.service.EmitterService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+
 @RestController
 @RequestMapping("/notices")
+@RequiredArgsConstructor
 @Slf4j
 public class NoticeController {
+
+    private final EmitterService emitterService;
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
 
     /**
@@ -18,30 +27,47 @@ public class NoticeController {
      * produces = MediaType.TEXT_EVENT_STREAM_VALUE 은 SSE 통신 규약
      */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe() {
-        log.info("새로운 SSE 연결 요청");
+    public SseEmitter subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        // 1. SseEmitter 객체 생성 및 타임아웃 설정
+        if (userDetails == null || userDetails.getMember() == null) {
+            log.warn("SSE 구독 요청 - 인증 정보 또는 사용자 정보 없음");
+            throw new IllegalArgumentException("사용자 인증 정보를 찾을 수 없습니다.");
+        }
+        Long userId = userDetails.getId();
+        log.info("새로운 SSE 연결 요청 for User ID: {}", userId);
+
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
-        log.info("SseEmitter 생성됨. 타임아웃: {}ms", DEFAULT_TIMEOUT);
+        log.info("SseEmitter 생성됨 for User ID: {}. 타임아웃: {}ms", userId, DEFAULT_TIMEOUT);
+        emitterService.addEmitter(userId, emitter);
+        log.info("Emitter 저장됨 for User ID: {}", userId);
 
-        // 2. 초기 연결 시 더미 데이터 전송 (클라이언트에서 연결 확인용)
-        //    연결이 성공적으로 수립되었음을 클라이언트에게 알리기 위해 초기 이벤트를 보낼 수 있습니다.
+        emitter.onCompletion(() -> {
+            log.info("SSE 연결 완료 (onCompletion) for User ID: {}", userId);
+            emitterService.removeEmitter(userId);
+        });
+
+        emitter.onTimeout(() -> {
+            log.warn("SSE 연결 시간 초과 (onTimeout) for User ID: {}", userId);
+            emitter.complete();
+        });
+
+        emitter.onError(throwable -> {
+            log.error("SSE 연결 오류 발생 (onError) for User ID: {}. Error: {}", userId, throwable.getMessage());
+            emitterService.removeEmitter(userId);
+        });
+
         try {
             emitter.send(SseEmitter.event()
-                            .id("0")
-                            .name("connect")
-                            .data("SSE connection established successfully.")
-                     .comment("연결 성공") // 주석 (클라이언트에게는 안보임)
+                    .id(userId + "_" + System.currentTimeMillis())
+                    .name("connect")
+                    .data("SSE connection established successfully. UserID: " + userId)
             );
-            log.info("초기 연결 확인 이벤트 전송 완료");
-        } catch (Exception e) {
-            log.error("초기 연결 확인 이벤트 전송 중 오류 발생", e);
-            emitter.completeWithError(e);
+            log.info("초기 연결 확인 이벤트 전송 완료. 사용자 ID: {}", userId);
+        } catch (IOException e) {
+            log.error("초기 연결 확인 이벤트 전송 중 오류 발생. 사용자 ID: {}", userId, e);
+            emitterService.removeEmitter(userId);
         }
 
-        // 3.  생성된 Emitter를 반환 (Spring이 클라이언트와의 연결을 관리)
-        //    아직은 생성만 하고 실제 알림 전송 로직은 다음 이슈에서 구현합니다.
         return emitter;
     }
 }

--- a/src/main/java/com/soda/notice/controller/NoticeController.java
+++ b/src/main/java/com/soda/notice/controller/NoticeController.java
@@ -1,17 +1,19 @@
 package com.soda.notice.controller;
 
 import com.soda.global.security.auth.UserDetailsImpl; // UserDetailsImpl import 확인
-import com.soda.notice.service.EmitterService;
+import com.soda.notice.service.NoticeService; // NoticeService 사용
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
+// import java.io.IOException; // 더 이상 필요 없음
 
 @RestController
 @RequestMapping("/notices")
@@ -19,55 +21,50 @@ import java.io.IOException;
 @Slf4j
 public class NoticeController {
 
-    private final EmitterService emitterService;
-    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    // EmitterService 대신 NoticeService 주입
+    private final NoticeService noticeService;
+    // DEFAULT_TIMEOUT 도 Controller 에서는 더 이상 필요 없음
 
     /**
      * 클라이언트가 실시간 알림을 구독하는 엔드포인트
-     * produces = MediaType.TEXT_EVENT_STREAM_VALUE 은 SSE 통신 규약
+     * @param userDetails 인증된 사용자 정보 (@AuthenticationPrincipal 사용)
+     * @return SseEmitter 객체 또는 에러 응답
      */
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        if (userDetails == null || userDetails.getMember() == null) {
-            log.warn("SSE 구독 요청 - 인증 정보 또는 사용자 정보 없음");
-            throw new IllegalArgumentException("사용자 인증 정보를 찾을 수 없습니다.");
+        Long userId;
+        try {
+            // 사용자 ID 추출 및 유효성 검증
+            if (userDetails == null || userDetails.getMember() == null) {
+                log.warn("SSE 구독 요청 - 인증 정보 또는 사용자 정보 없음");
+                // 인증 안됐거나 사용자 정보 없으면 401 Unauthorized 반환
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+            // UserDetailsImpl에서 사용자 ID 가져오기 (getMember().getId() 또는 직접 getId())
+            userId = userDetails.getId(); // UserDetailsImpl에 getId()가 있다고 가정
+            if (userId == null) {
+                log.warn("SSE 구독 요청 - User ID가 null입니다.");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); // ID 없으면 400 Bad Request
+            }
+            log.info("새로운 SSE 연결 요청 for User ID: {}", userId);
+        } catch (Exception e) {
+            // 사용자 정보 추출 중 예외 발생 시 (예: 캐스팅 실패 등)
+            log.error("SSE 구독 요청 - 사용자 ID 추출 실패", e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
-        Long userId = userDetails.getId();
-        log.info("새로운 SSE 연결 요청 for User ID: {}", userId);
-
-        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
-        log.info("SseEmitter 생성됨 for User ID: {}. 타임아웃: {}ms", userId, DEFAULT_TIMEOUT);
-        emitterService.addEmitter(userId, emitter);
-        log.info("Emitter 저장됨 for User ID: {}", userId);
-
-        emitter.onCompletion(() -> {
-            log.info("SSE 연결 완료 (onCompletion) for User ID: {}", userId);
-            emitterService.removeEmitter(userId);
-        });
-
-        emitter.onTimeout(() -> {
-            log.warn("SSE 연결 시간 초과 (onTimeout) for User ID: {}", userId);
-            emitter.complete();
-        });
-
-        emitter.onError(throwable -> {
-            log.error("SSE 연결 오류 발생 (onError) for User ID: {}. Error: {}", userId, throwable.getMessage());
-            emitterService.removeEmitter(userId);
-        });
 
         try {
-            emitter.send(SseEmitter.event()
-                    .id(userId + "_" + System.currentTimeMillis())
-                    .name("connect")
-                    .data("SSE connection established successfully. UserID: " + userId)
-            );
-            log.info("초기 연결 확인 이벤트 전송 완료. 사용자 ID: {}", userId);
-        } catch (IOException e) {
-            log.error("초기 연결 확인 이벤트 전송 중 오류 발생. 사용자 ID: {}", userId, e);
-            emitterService.removeEmitter(userId);
+            // NoticeService의 구독 메서드 호출
+            SseEmitter emitter = noticeService.subscribe(userId);
+            log.info("Controller: SSE 구독 요청 처리 완료 for User ID: {}", userId);
+            // 성공 시 200 OK 와 함께 SseEmitter 반환
+            return ResponseEntity.ok(emitter);
+        } catch (Exception e) {
+            // 서비스 레이어에서 발생한 예외 처리
+            log.error("SSE 구독 처리 중 컨트롤러에서 오류 발생 for User ID: {}", userId, e);
+            // 서버 내부 오류로 500 Internal Server Error 반환
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-
-        return emitter;
     }
 }

--- a/src/main/java/com/soda/notice/service/NoticeService.java
+++ b/src/main/java/com/soda/notice/service/NoticeService.java
@@ -1,0 +1,46 @@
+package com.soda.notice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NoticeService {
+
+    private final EmitterService emitterService;
+
+    /**
+     * 사용자의 알림 구독 요청을 처리합니다.
+     * EmitterService를 통해 SSE 연결을 생성하고 관리합니다.
+     *
+     * @param userId 구독을 요청하는 사용자의 ID
+     * @return 생성된 SseEmitter 객체
+     * @throws RuntimeException Emitter 생성/처리 중 오류 발생 시
+     */
+    public SseEmitter subscribe(Long userId) {
+        log.info("알림 구독 서비스 시작 for User ID: {}", userId);
+        try {
+            SseEmitter emitter = emitterService.createAndAddEmitter(userId);
+            log.info("Emitter 생성 및 등록 완료 by EmitterService for User ID: {}", userId);
+            return emitter;
+        } catch (Exception e) {
+            log.error("알림 구독 처리 중 오류 발생 for User ID: {}", userId, e);
+            throw new RuntimeException("SSE 구독 처리 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 특정 사용자에게 알림 데이터를 전송합니다.
+     * 실제 데이터 전송은 EmitterService에 위임합니다.
+     * @param userId 알림을 받을 사용자의 ID
+     * @param eventName 이벤트 이름 (예: "new_notice", "task_update")
+     * @param noticeData 전송할 알림 데이터 (DTO, String 등)
+     */
+    public void sendNotification(Long userId, String eventName, Object noticeData) {
+        log.info("알림 전송 요청 to User ID: {}, Event: {}", userId, eventName);
+        emitterService.sendNotification(userId, eventName, noticeData);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,6 @@ spring:
       - /members/find-id
       - /password/change
       - /refresh
-      - /notices/**
 
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
# 요약

<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

SSE 구독 기능의 안정성과 구조를 개선합니다.

-   **인증 적용:** `/notices/subscribe` 엔드포인트에 JWT 인증을 적용하고 `@AuthenticationPrincipal`을 사용합니다.
-   **서비스 분리:** `NoticeService`를 도입하여 Controller의 구독 로직을 분리했습니다.
-   **Emitter 자동 정리:** `EmitterService`에서 연결 종료/타임아웃/오류 시 자동으로 Emitter를 제거하도록 개선했습니다.
-   **알림 전송 기능 추가:** `EmitterService`에 특정 사용자 대상 알림 전송 메서드를 추가했습니다.

# 연관 이슈

Close #181

# Pull Request 체크리스트

## TODO

-   [x] 최종 결과물을 확인했는가?
-   [x] 의미 있는 커밋 메시지를 작성했는가?