### PR TITLE
[Feature] SSE 테스트 알림 전송 엔드포인트 추가

### DIFF
--- a/src/main/java/com/soda/notice/service/EmitterService.java
+++ b/src/main/java/com/soda/notice/service/EmitterService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EmitterService {
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
-    private static final Long DEFAULT_TIMEOUT = 5000L; //60L * 1000 * 60; // 1시간 (필요시 조정)
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 1시간 (필요시 조정)
 
     /**
      * 지정된 사용자 ID에 대한 SseEmitter를 생성하고 저장합니다.


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

SSE 기반 실시간 알림 기능의 개발 및 테스트를 용이하게 하기 위해, 특정 사용자에게 수동으로 테스트 알림을 전송할 수 있는 엔드포인트를 추가합니다.

-   **테스트 엔드포인트 구현:**
    -   `POST /notices/send-test/{userId}` 경로를 추가했습니다.
    -   이 엔드포인트는 Request Body로 받은 메시지(`{"message": "..."}`)를 지정된 `userId`를 구독 중인 클라이언트에게 `test_notification` 이벤트로 전송합니다.
    -   `NoticeService`의 `sendNotification` 메서드를 사용하여 실제 SSE 이벤트를 발생시킵니다.
-   **타임아웃 조정:**
    -   `EmitterService`의 `DEFAULT_TIMEOUT` 값을 다시 1시간으로 조정했습니다 (이전 임시 변경값 복구).
-   **목적:** 프론트엔드 개발 또는 백엔드 알림 로직 테스트 시, 실제 이벤트 발생을 기다리지 않고 SSE 연결 및 메시지 수신을 간편하게 확인할 수 있도록 지원합니다.

# 연관 이슈
Close #182

# Pull Request 체크리스트
## TODO
-   [x] 최종 결과물을 확인했는가?
-   [x] 의미 있는 커밋 메시지를 작성했는가?