### PR TITLE
[Fix] logstash.conf 환경변수 변경

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -9,7 +9,7 @@ input {
 
 output {
   mongodb {
-    uri => "${MONGODB_URI}?retryWrites=true&w=majority&appName=Cluster0&ssl=true"
+    uri => ${MONGODB_URI}
     database => "log"
     collection => "system_log"
     codec => "json"


### PR DESCRIPTION

# 요약
- logstash.conf 환경변수 변경

# 연관 이슈
#174 

# 확인해야할 사항
- 젠킨스 서버에서 logstash.conf 파일의 몽고db URI가 읽히지 않는 버그를 수정하였습니다.
- 기존에 .env의 환경변수 + 문자열로 읽히게 하던 것을 깔끔하게 환경변수에 문자열까지 함께 저장하고 conf파일에서 환경변수만 읽도록 수정하였습니다.