### PR TITLE
[Fix] logstash.conf 환경변수에 쌍따옴표("") 추가

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -9,7 +9,7 @@ input {
 
 output {
   mongodb {
-    uri => ${MONGODB_URI}
+    uri => "${MONGODB_URI}"
     database => "log"
     collection => "system_log"
     codec => "json"


### PR DESCRIPTION

# 요약
- logstash.conf 환경변수에 쌍따옴표("") 추가


# 연관 이슈
#174 

# 확인해야할 사항
- logstash.conf에서 실수로 쌍따옴표("")를 빠뜨려 추가합니다.
  - logstash.conf에서는 환경변수를 쌍따옴표("")로 감싸야 환경변수로 인식합니다.