### PR TITLE
[Fix] 게시글 조회 시 게시글 상태 조회 안되는 오류 수정

### DIFF
--- a/src/main/java/com/soda/article/dto/article/ArticleViewResponse.java
+++ b/src/main/java/com/soda/article/dto/article/ArticleViewResponse.java
@@ -2,6 +2,7 @@ package com.soda.article.dto.article;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.soda.article.entity.Article;
+import com.soda.article.enums.ArticleStatus;
 import com.soda.article.enums.PriorityType;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 public class ArticleViewResponse {
     private String title;
     private String content;
+    private ArticleStatus status;
     private PriorityType priority;
     private LocalDateTime deadLine;
     private String memberName;
@@ -28,6 +30,7 @@ public class ArticleViewResponse {
         return ArticleViewResponse.builder()
                 .title(article.getTitle())
                 .content(article.getContent())
+                .status(article.getStatus())
                 .priority(article.getPriority())
                 .deadLine(article.getDeadline())
                 .memberName(article.getMember().getName())


### PR DESCRIPTION

# 요약
게시글 조회 시 게시글 상태 조회 안되는 오류 수정

# 연관 이슈
#245 

# 확인 사항
- 게시글 하나 조회 시 게시글 상태 조회가 없어서 status를 추가해주었습니다.
- 답변완료/답변대기 상태 변경 API 연동 시 필요하기 때문에 추가했습니다.