### PR TITLE
[Feature] 회사 생성 추이 통계 조회 기능 구현

### DIFF
--- a/src/main/java/com/soda/member/controller/CompanyController.java
+++ b/src/main/java/com/soda/member/controller/CompanyController.java
@@ -1,10 +1,8 @@
 package com.soda.member.controller;
 
 import com.soda.global.response.ApiResponseForm;
-import com.soda.member.dto.company.CompanyCreateRequest;
-import com.soda.member.dto.company.CompanyUpdateRequest;
-import com.soda.member.dto.company.CompanyResponse;
-import com.soda.member.dto.company.MemberResponse;
+import com.soda.member.dto.CompanyCreationTrend;
+import com.soda.member.dto.company.*;
 import com.soda.member.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -65,5 +63,18 @@ public class CompanyController {
     public ResponseEntity<ApiResponseForm<List<MemberResponse>>> getCompanyMembers(@PathVariable Long id) {
         List<MemberResponse> members = companyService.getCompanyMembers(id);
         return ResponseEntity.ok(ApiResponseForm.success(members, "회사 멤버 정보 조회 성공"));
+    }
+
+    /**
+     * 지정된 기간 및 단위로 회사 생성 추이 조회 API
+     * @param searchCondition 검색 조건 DTO (unit, startDate, endDate 포함)
+     * @return 기간별 생성 건수 리스트 응답
+     */
+    @GetMapping("/company-creation-trend")
+    public ResponseEntity<ApiResponseForm<List<CompanyCreationTrend>>> getCompanyCreationTrend(
+            @ModelAttribute CompanyTrendSearchCondition searchCondition
+    ) {
+        List<CompanyCreationTrend> trendData = companyService.getCompanyCreationTrend(searchCondition);
+        return ResponseEntity.ok(ApiResponseForm.success(trendData, "회사 생성 추이 조회 성공"));
     }
 }

--- a/src/main/java/com/soda/member/dto/CompanyCreationStatRaw.java
+++ b/src/main/java/com/soda/member/dto/CompanyCreationStatRaw.java
@@ -1,0 +1,16 @@
+package com.soda.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyCreationStatRaw {
+    private int year;
+    private int month;
+    private int weekOfYear;
+    private int dayOfMonth;
+    private long count;
+}

--- a/src/main/java/com/soda/member/dto/CompanyCreationTrend.java
+++ b/src/main/java/com/soda/member/dto/CompanyCreationTrend.java
@@ -1,0 +1,16 @@
+package com.soda.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyCreationTrend {
+
+    private String period;
+
+    private long count;
+
+}

--- a/src/main/java/com/soda/member/dto/company/CompanyTrendSearchCondition.java
+++ b/src/main/java/com/soda/member/dto/company/CompanyTrendSearchCondition.java
@@ -1,0 +1,22 @@
+package com.soda.member.dto.company;
+
+import com.soda.member.enums.StatisticsUnit;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class CompanyTrendSearchCondition {
+
+    private StatisticsUnit unit;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+}

--- a/src/main/java/com/soda/member/enums/StatisticsUnit.java
+++ b/src/main/java/com/soda/member/enums/StatisticsUnit.java
@@ -1,0 +1,70 @@
+package com.soda.member.enums;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+
+@Getter
+public enum StatisticsUnit {
+    DAY("yyyy-MM-dd") {
+        @Override
+        public LocalDate getStartOfPeriod(LocalDate date) { return date; }
+        @Override
+        public LocalDate getNextPeriodStart(LocalDate date) { return date.plusDays(1); }
+        @Override
+        public String formatPeriod(LocalDate date) {
+            return date.format(DateTimeFormatter.ofPattern(getDisplayFormat()));
+        }
+    },
+
+    WEEK("yyyy-MM-Wn") {
+        private static final WeekFields TARGET_WEEK_FIELDS = WeekFields.ISO;
+        @Override
+        public LocalDate getStartOfPeriod(LocalDate date) { return date.with(TARGET_WEEK_FIELDS.dayOfWeek(), 1); }
+        @Override
+        public LocalDate getNextPeriodStart(LocalDate date) { return getStartOfPeriod(date).plusWeeks(1); }
+        @Override
+        public String formatPeriod(LocalDate date) {
+            YearMonth currentYearMonth = YearMonth.from(date);
+            int weekOfMonth = date.get(TARGET_WEEK_FIELDS.weekOfMonth());
+            return String.format("%s-W%d",
+                    currentYearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM")),
+                    weekOfMonth);
+        }
+    },
+
+    MONTH("yyyy-MM") {
+        @Override
+        public LocalDate getStartOfPeriod(LocalDate date) { return date.withDayOfMonth(1); }
+        @Override
+        public LocalDate getNextPeriodStart(LocalDate date) { return getStartOfPeriod(date).plusMonths(1); }
+        @Override
+        public String formatPeriod(LocalDate date) {
+            return YearMonth.from(date).format(DateTimeFormatter.ofPattern(getDisplayFormat()));
+        }
+    };
+
+    private final String displayFormat;
+
+    StatisticsUnit(String displayFormat) {
+        this.displayFormat = displayFormat;
+    }
+
+    public abstract LocalDate getStartOfPeriod(LocalDate date);
+    public abstract LocalDate getNextPeriodStart(LocalDate date);
+    public abstract String formatPeriod(LocalDate date);
+
+    public static StatisticsUnit fromString(String text) {
+        if (text != null) {
+            for (StatisticsUnit unit : StatisticsUnit.values()) {
+                if (text.equalsIgnoreCase(unit.name())) {
+                    return unit;
+                }
+            }
+        }
+        return MONTH;
+    }
+}

--- a/src/main/java/com/soda/member/repository/CompanyRepository.java
+++ b/src/main/java/com/soda/member/repository/CompanyRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CompanyRepository extends JpaRepository<Company, Long> {
+public interface CompanyRepository extends JpaRepository<Company, Long>, CompanyRepositoryCustom {
     Optional<Company> findByIdAndIsDeletedFalse(Long companyId);
 
     List<Company> findByIsDeletedFalse();

--- a/src/main/java/com/soda/member/repository/CompanyRepositoryCustom.java
+++ b/src/main/java/com/soda/member/repository/CompanyRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.soda.member.repository;
+
+import com.soda.member.dto.CompanyCreationStatRaw;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CompanyRepositoryCustom {
+    List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDate, LocalDateTime endDate);
+}

--- a/src/main/java/com/soda/member/repository/CompanyRepositoryImpl.java
+++ b/src/main/java/com/soda/member/repository/CompanyRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.soda.member.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soda.member.dto.CompanyCreationStatRaw;
+import com.soda.member.entity.QCompany;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CompanyRepositoryImpl implements CompanyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDate, LocalDateTime endDate) {
+        QCompany company = QCompany.company;
+
+        NumberExpression<Integer> year = company.createdAt.year();
+        NumberExpression<Integer> month = company.createdAt.month();
+        NumberExpression<Integer> week = company.createdAt.week();
+        NumberExpression<Integer> day = company.createdAt.dayOfMonth();
+
+        return queryFactory
+                .select(Projections.constructor(CompanyCreationStatRaw.class,
+                        year,
+                        month,
+                        week,
+                        day,
+                        company.count().as("count")
+                ))
+                .from(company)
+                .where(
+                        company.createdAt.goe(startDate),
+                        company.createdAt.lt(endDate),
+                        company.isDeleted.isFalse()
+                )
+                .groupBy(year, month, week, day)
+                .orderBy(year.asc(), month.asc(), day.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/soda/member/service/CompanyService.java
+++ b/src/main/java/com/soda/member/service/CompanyService.java
@@ -3,11 +3,11 @@ package com.soda.member.service;
 
 import com.soda.global.log.dataLog.annotation.LoggableEntityAction;
 import com.soda.global.response.GeneralException;
-import com.soda.member.dto.company.CompanyCreateRequest;
-import com.soda.member.dto.company.CompanyResponse;
-import com.soda.member.dto.company.CompanyUpdateRequest;
-import com.soda.member.dto.company.MemberResponse;
+import com.soda.member.dto.CompanyCreationStatRaw;
+import com.soda.member.dto.CompanyCreationTrend;
+import com.soda.member.dto.company.*;
 import com.soda.member.entity.Company;
+import com.soda.member.enums.StatisticsUnit;
 import com.soda.member.error.CompanyErrorCode;
 import com.soda.member.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -82,7 +86,7 @@ public class CompanyService {
     /**
      * 회사 수정 메서드
      *
-     * @param id 회사 ID
+     * @param id      회사 ID
      * @param request 회사 수정 요청 DTO
      * @return 수정된 회사 정보 DTO
      * @throws GeneralException 회사를 찾을 수 없는 경우 또는 사업자 등록번호 중복 시 발생
@@ -154,6 +158,7 @@ public class CompanyService {
 
     /**
      * 활성 상태인 회사 엔티티 조회 (ID 기반, 내부 또는 다른 서비스에서 사용)
+     *
      * @param companyId 회사 ID
      * @return Company 엔티티
      * @throws GeneralException 회사를 찾을 수 없거나 삭제된 경우 발생
@@ -164,5 +169,67 @@ public class CompanyService {
                     log.error("회사 조회 실패: ID {} 에 해당하는 활성 회사를 찾을 수 없음", companyId);
                     return new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY);
                 });
+    }
+
+    public List<CompanyCreationTrend> getCompanyCreationTrend(CompanyTrendSearchCondition condition) {
+
+        StatisticsUnit unit = (condition.getUnit() != null) ? condition.getUnit() : StatisticsUnit.MONTH;
+        LocalDate endDate = (condition.getEndDate() != null) ? condition.getEndDate() : LocalDate.now();
+        LocalDate startDate = (condition.getStartDate() != null) ? condition.getStartDate() : calculateDefaultStartDate(unit, endDate);
+
+        if (startDate.isAfter(endDate)) {
+            log.warn("조회 기간 오류: 시작일({})이 종료일({})보다 이후입니다.", startDate, endDate);
+            return new ArrayList<>();
+        }
+
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
+
+        List<CompanyCreationStatRaw> rawData = companyRepository.countCompaniesByDayRaw(startDateTime, endDateTime);
+
+        Map<String, Long> aggregatedData = rawData.stream()
+                .collect(Collectors.groupingBy(
+                        raw -> formatPeriodKey(raw, unit),
+                        LinkedHashMap::new,
+                        Collectors.summingLong(CompanyCreationStatRaw::getCount)
+                ));
+
+        return generateFullPeriodList(startDate, endDate, unit).stream()
+                .map(periodStr -> {
+                    long count = aggregatedData.getOrDefault(periodStr, 0L);
+                    return new CompanyCreationTrend(periodStr, count);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String formatPeriodKey(CompanyCreationStatRaw raw, StatisticsUnit unit) {
+        LocalDate date = LocalDate.of(raw.getYear(), raw.getMonth(), raw.getDayOfMonth());
+        switch (unit) {
+            case DAY:
+                return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            case WEEK:
+                return StatisticsUnit.WEEK.formatPeriod(date);
+            case MONTH:
+            default:
+                return YearMonth.from(date).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        }
+    }
+
+    private LocalDate calculateDefaultStartDate(StatisticsUnit unit, LocalDate endDate) {
+        return switch (unit) {
+            case DAY -> endDate.minusDays(6);
+            case WEEK -> endDate.minusWeeks(3).with(WeekFields.ISO.dayOfWeek(), 1);
+            case MONTH -> endDate.minusMonths(3).withDayOfMonth(1);
+        };
+    }
+
+    private List<String> generateFullPeriodList(LocalDate startDate, LocalDate endDate, StatisticsUnit unit) {
+        List<String> periods = new ArrayList<>();
+        LocalDate currentDate = unit.getStartOfPeriod(startDate);
+        while (!currentDate.isAfter(endDate)) {
+            periods.add(unit.formatPeriod(currentDate));
+            currentDate = unit.getNextPeriodStart(currentDate);
+        }
+        return periods.stream().distinct().sorted().collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
# 요약

<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

관리자가 지정된 기간 및 단위(일/주/월)에 따라 회사 생성 추이를 조회하는 API를 구현했습니다. 
관리자 대시보드에서 사용될 기능입니다.


## 주요 구현 내용

1.  **API 엔드포인트 추가:** GET /companies/company-creation-trend
2.  **StatisticsUnit Enum 생성:** 일/주/월 단위별 기간 계산 및 포맷팅 로직 캡슐화
3.  **QueryDSL Repository 구현:** CompanyRepositoryCustom 및 구현체 추가, 생성일 기준 Raw 데이터 조회 
4.  **서비스 로직 구현 (`CompanyService`):**
    *   Raw 데이터 기반 요청 단위별 집계
    *   데이터 없는 기간 0으로 채우는 Zero-Filling 로직 구현
5.  **관련 DTO 추가:** `CompanyTrendSearchCondition`, `CompanyCreationStatRaw`, `CompanyCreationTrend`

## 설계 고려 사항 및 향후 개선 계획

*   **현재 방식:** 실시간 DB 조회 및 집계 (관리자 기능이라 낮은 빈도로 요청될 것 같아 실시간 DB조회로 구현)
*   **성능 이슈 발생 시:** 배치 작업으로 통계 테이블 사전 계산 방식 도입 하겠습니다.

# 연관 이슈

Close #239

# Pull Request 체크리스트

## TODO

-   [x] 최종 결과물을 확인했는가?
-   [x] 의미 있는 커밋 메시지를 작성했는가?