### PR TITLE
[Fix&Refact] 저장시각이 문자열로 저장되는 버그 해결, 필요없는 필드 삭제, INFO레벨 이상만 로깅되게 수정

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -7,11 +7,35 @@ input {
   }
 }
 
+filter {
+  mutate {
+      remove_field => ["@version", "path", "host", "thread"]
+  }
+  date {
+    match => ["time", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"]
+    target => "@timestamp"
+    timezone => "Asia/Seoul"
+    remove_field => ["time"]
+  }
+  mutate {
+    rename => { "@timestamp" => "timestamp" }
+  }
+}
+
 output {
-  mongodb {
-    uri => "${MONGODB_URI}"
-    database => "log"
-    collection => "system_log"
-    codec => "json"
+  if [level] == "ERROR" {
+    mongodb {
+      uri => "${MONGODB_URI}"
+      database => "log"
+      collection => "error_log"
+      isodate => true
+    }
+  } else {
+    mongodb {
+      uri => "${MONGODB_URI}"
+      database => "log"
+      collection => "system_log"
+      isodate => true
+    }
   }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,13 +19,11 @@
             <providers>
                 <timestamp>
                     <fieldName>time</fieldName>
+                    <pattern>yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ</pattern>
                 </timestamp>
                 <loggerName>
                     <fieldName>logger</fieldName>
                 </loggerName>
-                <threadName>
-                    <fieldName>thread</fieldName>
-                </threadName>
                 <logLevel>
                     <fieldName>level</fieldName>
                 </logLevel>
@@ -39,6 +37,11 @@
                 </callerData>
             </providers>
         </encoder>
+
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
     </appender>
 
     <root level="INFO">


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 저장시각이 문자열로 저장되는 버그 해결, 필요없는 필드 삭제, INFO레벨 이상만 로깅되게 수정

# 연관 이슈
#248 

# 확인해야할 사항
- 기존에 문자열로 저장되던 로깅시각을 ISO시간형식으로 저장되게 하였음. 현재 시간역순으로 정렬이 잘되고, 차후 검색 등이 요구되면 인덱싱 전략 적용 가능함. 
- "@version", "path", "host", "thread" 등의 필요없는 필드를 삭제하였음.
- 콘솔에는 모든 레벨의 로그가, 파일에 던질때는 INFO레벨 이상만 로깅되게하여 몽고DB에는 INFO레벨 이상의 로그만 저장되게 하였고, 몽고DB에 error_log라는 별도의 컬렉션을 만들어 ERROR레벨의 로그는 error_log에 따로 저장되게 만듦.

- 변경 전
![image](https://github.com/user-attachments/assets/5393a152-8c51-4c23-8cd5-8610b525eb20)

- 변경 후
![image](https://github.com/user-attachments/assets/84a8f1fe-365c-4b94-b92d-8793a21969cc)
몽고DB Compass에서 timestamp 기준으로 최신순 정렬이 잘 되는 모습.