### PR TITLE
[Fix] 몽고DB에 중복로깅되는 버그 해결

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -2,7 +2,7 @@ input {
   file {
     path => "/usr/share/logstash/logs/*.json"
     start_position => "beginning"
-    sincedb_path => "/dev/null"
+    sincedb_path => "/usr/share/logstash/data/plugins/inputs/file/.sincedb"
     codec => "json"
   }
 }

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -2,7 +2,7 @@ input {
   file {
     path => "/usr/share/logstash/logs/*.json"
     start_position => "beginning"
-    sincedb_path => "/usr/share/logstash/data/plugins/inputs/file/.sincedb"
+    sincedb_path => "/usr/share/logstash/data/.sincedb"
     codec => "json"
   }
 }


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 몽고DB에 중복로깅되는 버그 해결

# 연관 이슈
#250 

# 확인해야할 사항
- logstash의 이전에 읽은 파일 정보 기억하게 (sicedb_path) 설정하여 해결