### PR TITLE
[Feature] 로그 생성시간/로깅시간 구분하여 로깅

### DIFF
--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -14,11 +14,10 @@ filter {
   date {
     match => ["time", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"]
     target => "@timestamp"
-    timezone => "Asia/Seoul"
-    remove_field => ["time"]
   }
   mutate {
-    rename => { "@timestamp" => "timestamp" }
+    rename => { "time" => "created_time" }
+    rename => { "@timestamp" => "logging_time" }
   }
 }
 


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 로그 생성시간/로깅시간 구분하여 로깅

# 연관 이슈
#252 

# 확인해야할 사항
- 로그가 생성된 시간과 실제로 몽고DB에 로깅되는 시간을 구분하여 필드에 기록함으로써 중복로깅이나 로깅지연과 같은 문제를 감지하기 용이하게 만듦.
  - 로그가 생성된 시간은 created_time, 로깅된 시간은 logging_time 필드에 저장됨.