### PR TITLE
[Fix] 프로젝트 생성을 하지 않는 경우 통계에 저장되지 않는 오류 해결

### DIFF
--- a/src/main/java/com/soda/project/service/ProjectService.java
+++ b/src/main/java/com/soda/project/service/ProjectService.java
@@ -936,11 +936,16 @@ public class ProjectService {
                 LocalDate endWeekStart = endDate.with(weekFields.dayOfWeek(), 1); // 종료일이 속한 주의 시작일 (월요일)
 
                 while (!currentWeekStart.isAfter(endWeekStart)) {
-                    String dateKey = currentWeekStart.format(DateTimeFormatter.ofPattern("yyyy-ww", Locale.KOREA));
-                    long count = statsMap.getOrDefault(dateKey, 0L);
+
+                    String repositoryDateKey = currentWeekStart.format(DateTimeFormatter.ofPattern("yyyy-ww", Locale.KOREA));
+                    int year = currentWeekStart.getYear();
+                    int month = currentWeekStart.getMonthValue();
+                    int weekOfMonth = currentWeekStart.get(weekFields.weekOfMonth());
+                    String displayDateString = String.format("%d년 %d월 %d주차", year, month, weekOfMonth);
+                    long count = statsMap.getOrDefault(repositoryDateKey, 0L);
 
                     fullTrend.add(ProjectStatsResponse.DataPoint.builder()
-                            .date(dateKey)
+                            .date(displayDateString)
                             .count(count)
                             .build());
                     currentWeekStart = currentWeekStart.plusWeeks(1);


### PR DESCRIPTION

# 요약

만약 조회하려는 기간에 프로젝트를 생성하지 않으면 통계 테이블에 해당 날짜가 저장되지 않아 조회되지 않는 오류를 해결하였습니다.

# 연관 이슈
#259 

# 확인 사항
### `generateFullTrendData` 메서드 생성
- 조회하려는 기간 중 통계 테이블에 존재하지 않는 날짜인 경우 `count 0`으로 조회하도록 추가하였습니다.
- 요청된 timeUnit에 따라 startDate부터 endDate까지 모든 기간(일/주/월)을 반복합니다.
- DAY
   - while 루프와 plusDays(1)을 사용하여 명시적으로 반복합니다
   - 각 날짜를 yyyy-MM-dd 형식의 dateKey로 만듭니다.
- WEEK
   - 시작일과 종료일이 속한 주의 시작일(월요일 기준, WeekFields 사용)을 계산하고, while 루프와 plusWeeks(1)로 반복합니다. 
   - 각 주의 시작일에 대해 Repository에서 사용한 주차 형식과 동일한 dateKey 를 생성합니다
   - "2025년 4월 둘째주" 이런 식으로 날짜를 조회하기 위해 따로 조회용 날짜 문자열을 생성하였습니다.
- MONTH
   - YearMonth와 while 루프, plusMonths(1)을 사용하여 반복합니다. 
   - 각 월을 yyyy-MM 형식의 dateKey로 만듭니다.
### 서비스 로직에서 메서드를 만든 이유
1. DB 부하 감소
   - 데이터베이스는 실제 데이터가 있는 행만 조회하고 집계(GROUP BY, SUM)하면 됩니다.
   - 0건인 날짜를 DB에서 억지로 만들어내거나 조인할 필요가 없습니다
   - 이는 DB 쿼리를 훨씬 단순하고 빠르게 만듭니다.
2. 유지보수: 통계 표시 방식(0 포함 여부 등) 변경 시 서비스 로직만 수정하면 됩니다.
### 기타
이런 식으로 서비스 로직에서 데이터가 없는 경우 0으로 조회되게끔 만들었는데,
조회 기간이 매우 길면 (예: 몇 년치 일별 데이터) 이 반복 작업이 약간의 CPU 및 메모리 자원을 사용할 수 있을 거라고 생각합니다.
DB 조회보다는 빠르겠지만 이런 식으로 구현하는게 좋을지 고민을 해봐야할 것 같습니다.