### PR TITLE
[Feature] 게시글 목록 조회 시 PriorityType, ArticleStatus 필터링 기능 추가

### DIFF
--- a/src/main/java/com/soda/article/dto/article/ArticleSearchCondition.java
+++ b/src/main/java/com/soda/article/dto/article/ArticleSearchCondition.java
@@ -1,5 +1,7 @@
 package com.soda.article.dto.article;
 
+import com.soda.article.enums.ArticleStatus;
+import com.soda.article.enums.PriorityType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,6 +15,9 @@ public class ArticleSearchCondition {
 
     private SearchType searchType;
     private String keyword;
+
+    private ArticleStatus status;
+    private PriorityType priorityType;
 
     public enum SearchType {
         TITLE_CONTENT,

--- a/src/main/java/com/soda/article/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/com/soda/article/repository/ArticleRepositoryImpl.java
@@ -1,11 +1,14 @@
 package com.soda.article.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soda.article.dto.article.ArticleSearchCondition;
 import com.soda.article.entity.Article;
+import com.soda.article.enums.ArticleStatus;
+import com.soda.article.enums.PriorityType;
 import com.soda.member.entity.QCompany;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -105,7 +108,9 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                         stage.project.id.eq(projectId),
                         article.isDeleted.isFalse(),
                         stageIdEq(request.getStageId()),
-                        searchCondition(request.getSearchType(), request.getKeyword())
+                        searchCondition(request.getSearchType(), request.getKeyword()),
+                        articleStatusEq(request.getStatus()),
+                        priorityTypeEq(request.getPriorityType())
                 )
                 .orderBy(article.createdAt.desc()) // 기본 정렬, Pageable 정렬 처리 필요시 추가
                 .offset(pageable.getOffset())
@@ -126,6 +131,14 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                 );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression priorityTypeEq(PriorityType priorityType) {
+        return priorityType != null ? article.priority.eq(priorityType) : null;
+    }
+
+    private BooleanExpression articleStatusEq(ArticleStatus status) {
+        return status != null ? article.status.eq(status) : null;
     }
 
     // 프로젝트 ID 필터링 조건 (project 별칭 사용)


### PR DESCRIPTION

# 요약
게시글 목록 조회 시
우선순위 / 게시글 상태 별로 필터링해서 조회하는 기능을 추가했습니다.

# 연관 이슈
#265 


# 확인 사항
- `ArticleSearchCondition`에 PriorityType, ArticleStatus 추가
- `searchArticles` 메서드에 해당 필터링 조건 추가