### PR TITLE
[Fix] 응답시간 로깅시 중괄호를 하나 더 넣어 응답시간이 부정확한 위치에 로깅되는 버그 해결

### DIFF
--- a/src/main/java/com/soda/global/log/responsetime/ControllerLoggingAspect.java
+++ b/src/main/java/com/soda/global/log/responsetime/ControllerLoggingAspect.java
@@ -26,9 +26,9 @@ public class ControllerLoggingAspect {
             String requestUri = request.getRequestURI();
             String httpMethod = request.getMethod();
             if(end - start > 1000) {
-                log.warn("[API Response Time] {} {} {} executed in {} ms", httpMethod, requestUri, (end - start));
+                log.warn("[API Response Time] {} {} executed in {} ms", httpMethod, requestUri, (end - start));
             } else {
-                log.info("[API Response Time] {} {} {} executed in {} ms", httpMethod, requestUri, (end - start));
+                log.info("[API Response Time] {} {} executed in {} ms", httpMethod, requestUri, (end - start));
             }
         }
     }


### PR DESCRIPTION

# 요약
- 응답시간 로깅시 중괄호를 하나 더 넣어 응답시간이 부정확한 위치에 로깅되는 버그 해결


# 연관 이슈
#270 
