### PR TITLE
[Feature] 사용자 알림 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -14,9 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
@@ -56,5 +54,45 @@ public class NotificationController {
         Page<NotificationResponse> notificationPage = notificationService.getNotifications(currentMemberId, pageable);
         log.info("사용자 알림 목록 조회 성공 - User ID: {}, 조회된 항목 수: {}", currentMemberId, notificationPage.getNumberOfElements());
         return ResponseEntity.ok(ApiResponseForm.success(notificationPage, "알림 목록 조회 성공"));
+    }
+
+    /**
+     * 특정 알림을 읽음 상태로 변경합니다.
+     * (이전에 수정한 코드와 동일한 형식 유지)
+     *
+     * @param memberNotificationId 읽음 처리할 MemberNotification의 ID
+     * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
+     */
+    @PatchMapping("/{memberNotificationId}/read")
+    public ResponseEntity<ApiResponseForm<Void>> markNotificationAsRead(
+            @PathVariable Long memberNotificationId,
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("알림 읽음 처리 요청 - User ID: {}, MemberNotification ID: {}", currentMemberId, memberNotificationId);
+
+        notificationService.markAsRead(currentMemberId, memberNotificationId);
+        log.info("알림 읽음 처리 성공 - User ID: {}, MemberNotification ID: {}", currentMemberId, memberNotificationId);
+        return ResponseEntity.ok(ApiResponseForm.success(null, "알림 읽음 처리 성공"));
+
+    }
+
+    /**
+     * 현재 로그인한 사용자의 모든 읽지 않은 알림을 읽음 상태로 변경합니다.
+     *
+     * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
+     */
+    @PatchMapping("/read-all")
+    public ResponseEntity<ApiResponseForm<Void>> markAllNotificationsAsRead(
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("사용자 모든 알림 읽음 처리 요청 - User ID: {}", currentMemberId);
+
+        notificationService.markAllAsReadIterative(currentMemberId);
+        log.info("사용자 모든 알림 읽음 처리 성공 - User ID: {}", currentMemberId);
+
+        return ResponseEntity.ok(ApiResponseForm.success(null, "모든 알림 읽음 처리 성공"));
+
     }
 }

--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -1,20 +1,19 @@
 package com.soda.notification.controller;
 
+import com.soda.global.response.ApiResponseForm;
 import com.soda.global.response.GeneralException;
-import com.soda.global.security.auth.UserDetailsImpl;
 import com.soda.notification.dto.NotificationResponse;
 import com.soda.notification.error.NotificationErrorCode;
 import com.soda.notification.service.NotificationService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,66 +21,40 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
 @RestController
-@RequestMapping("/notices")
+@RequestMapping("/notifications")
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationController {
 
     private final NotificationService notificationService;
 
-    /**
-     * 클라이언트가 실시간 알림을 구독하는 엔드포인트
-     *
-     * @param userDetails 인증된 사용자 정보 (@AuthenticationPrincipal 사용)
-     * @return SseEmitter 객체 또는 에러 응답
-     */
+
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<SseEmitter> subscribe(HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
 
-        Long userId;
-        try {
-            if (userDetails == null || userDetails.getMember() == null) {
-                throw new GeneralException(NotificationErrorCode.USER_INFO_NOT_FOUND);
-            }
-            userId = userDetails.getId();
-            if (userId == null) {
-                throw new GeneralException(NotificationErrorCode.USER_ID_NULL);
-            }
-            log.info("새로운 SSE 연결 요청 for User ID: {}", userId);
-        } catch (Exception e) {
-            log.error("SSE 구독 요청 - 사용자 ID 추출 실패", e);
-            throw new GeneralException(NotificationErrorCode.USER_ID_PARSE_FAILED);
-        }
+        log.info("새로운 SSE 연결 요청 for User ID: {}", currentMemberId);
 
         try {
-            SseEmitter emitter = notificationService.subscribe(userId);
-            log.info("Controller: SSE 구독 요청 처리 완료 for User ID: {}", userId);
+            SseEmitter emitter = notificationService.subscribe(currentMemberId);
+            log.info("Controller: SSE 구독 요청 처리 완료 for User ID: {}", currentMemberId);
             return ResponseEntity.ok(emitter);
         } catch (Exception e) {
-            log.error("SSE 구독 처리 중 컨트롤러에서 오류 발생 for User ID: {}", userId, e);
+            log.error("SSE 구독 처리 중 컨트롤러에서 오류 발생 for User ID: {}", currentMemberId, e);
             throw new GeneralException(NotificationErrorCode.SSE_CONNECTION_ERROR);
         }
     }
 
-    /**
-     * 현재 로그인한 사용자의 알림 목록을 페이징하여 조회합니다.
-     *
-     * @param userDetails 현재 로그인한 사용자 정보
-     * @param pageable    페이징 정보
-     * @return 페이징된 알림 목록 응답
-     */
     @GetMapping
-    public ResponseEntity<Page<NotificationResponse>> getMyNotifications(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Long userId = userDetails.getId();
-        log.info("사용자 알림 목록 조회 요청 - User ID: {}, Pageable: {}", userId, pageable);
-        try {
-            Page<NotificationResponse> notificationPage = notificationService.getNotifications(userId, pageable);
-            return ResponseEntity.ok(notificationPage);
-        } catch (Exception e) {
-            log.error("알림 목록 조회 중 오류 발생 - User ID: {}", userId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
+    public ResponseEntity<ApiResponseForm<Page<NotificationResponse>>> getMyNotifications(
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("사용자 알림 목록 조회 요청 - User ID: {}, Pageable: {}", currentMemberId, pageable);
+
+        Page<NotificationResponse> notificationPage = notificationService.getNotifications(currentMemberId, pageable);
+        log.info("사용자 알림 목록 조회 성공 - User ID: {}, 조회된 항목 수: {}", currentMemberId, notificationPage.getNumberOfElements());
+        return ResponseEntity.ok(ApiResponseForm.success(notificationPage, "알림 목록 조회 성공"));
     }
 }

--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -2,10 +2,16 @@ package com.soda.notification.controller;
 
 import com.soda.global.response.GeneralException;
 import com.soda.global.security.auth.UserDetailsImpl;
+import com.soda.notification.dto.NotificationResponse;
 import com.soda.notification.error.NotificationErrorCode;
 import com.soda.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -54,6 +60,28 @@ public class NotificationController {
         } catch (Exception e) {
             log.error("SSE 구독 처리 중 컨트롤러에서 오류 발생 for User ID: {}", userId, e);
             throw new GeneralException(NotificationErrorCode.SSE_CONNECTION_ERROR);
+        }
+    }
+
+    /**
+     * 현재 로그인한 사용자의 알림 목록을 페이징하여 조회합니다.
+     *
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @param pageable    페이징 정보
+     * @return 페이징된 알림 목록 응답
+     */
+    @GetMapping
+    public ResponseEntity<Page<NotificationResponse>> getMyNotifications(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Long userId = userDetails.getId();
+        log.info("사용자 알림 목록 조회 요청 - User ID: {}, Pageable: {}", userId, pageable);
+        try {
+            Page<NotificationResponse> notificationPage = notificationService.getNotifications(userId, pageable);
+            return ResponseEntity.ok(notificationPage);
+        } catch (Exception e) {
+            log.error("알림 목록 조회 중 오류 발생 - User ID: {}", userId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }

--- a/src/main/java/com/soda/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/soda/notification/dto/NotificationResponse.java
@@ -1,0 +1,53 @@
+package com.soda.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.soda.notification.entity.MemberNotification;
+import com.soda.notification.entity.Notification;
+import com.soda.notification.enums.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationResponse {
+
+    private final NotificationType type;
+    private final String message;
+    private final String link;
+
+    private final Long memberNoticeId;
+    private final Long notificationId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    @Builder
+    private NotificationResponse(Long memberNoticeId, Long notificationId, NotificationType type,
+                                 String message, String link, LocalDateTime createdAt) {
+        this.memberNoticeId = memberNoticeId;
+        this.notificationId = notificationId;
+        this.type = type;
+        this.message = message;
+        this.link = link;
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * MemberNotice 엔티티로부터 DTO를 생성하는 정적 팩토리 메서드
+     *
+     * @param memberNotification 조회된 MemberNotice 엔티티
+     * @return 생성된 NotificationResponseDto
+     */
+    public static NotificationResponse fromEntity(MemberNotification memberNotification) {
+        Notification notification = memberNotification.getNotification();
+        return NotificationResponse.builder()
+                .memberNoticeId(memberNotification.getId())
+                .notificationId(notification.getId())
+                .type(notification.getNotificationType())
+                .message(notification.getMessage())
+                .link(notification.getLink())
+                .createdAt(memberNotification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/soda/notification/entity/MemberNotification.java
+++ b/src/main/java/com/soda/notification/entity/MemberNotification.java
@@ -21,17 +21,15 @@ public class MemberNotification extends BaseEntity {
     @JoinColumn(name = "notification_id", nullable = false)
     private Notification notification;
 
-    @Column(nullable = false)
-    private boolean isRead = false;
 
     @Builder
     public MemberNotification(Member member, Notification notification) {
         this.member = member;
         this.notification = notification;
-        this.isRead = false;
     }
 
-    public void markAsRead() {
-        this.isRead = true;
+    public void Deleted() {
+        this.markAsDeleted();
     }
+
 }

--- a/src/main/java/com/soda/notification/error/NotificationErrorCode.java
+++ b/src/main/java/com/soda/notification/error/NotificationErrorCode.java
@@ -9,7 +9,9 @@ public enum NotificationErrorCode implements ErrorCode { // <<< 클래스명 수
     USER_ID_NULL("2402", "SSE 구독 요청 - User ID가 null입니다.", HttpStatus.BAD_REQUEST),
     USER_ID_PARSE_FAILED("2403", "SSE 구독 요청 - 사용자 ID 추출에 실패했습니다.", HttpStatus.BAD_REQUEST),
 
-    SSE_CONNECTION_ERROR("2404", "SSE 구독 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    SSE_CONNECTION_ERROR("2404", "SSE 구독 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_NOT_FOUND("2405", "해당 알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FORBIDDEN_ACCESS_NOTIFICATION("2406", "해당 알림에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
+++ b/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
@@ -42,7 +42,7 @@ public class CommentNotificationListener {
                 // 이벤트 정보로 알림 데이터 생성
                 String message = String.format("'%s'님이 '%s' 게시글에 댓글을 남겼습니다:\n%s",
                         event.commenterNickname(), event.articleTitle(), truncateContent(event.commentContent()));
-                String link = String.format("/user/projects/%d/article/%d", event.articleId(), event.commentId());
+                String link = String.format("/user/projects/%d/articles/%d", event.articleId(), event.commentId());
 
                 // NotificationData의 정적 팩토리 메서드 사용
                 NotificationData notificationData = NotificationData.forNewComment(
@@ -84,7 +84,7 @@ public class CommentNotificationListener {
                 NotificationData notificationData;
                 String eventName;
 
-                String link = String.format("/user/projects/%d/article/%d", event.projectId(), event.articleId(), event.replyId());
+                String link = String.format("/user/projects/%d/articles/%d", event.projectId(), event.articleId());
                 String truncatedContent = truncateContent(event.replyContent());
 
                 if (Objects.equals(targetUserId, articleAuthorId)) {
@@ -131,14 +131,14 @@ public class CommentNotificationListener {
                     .taskId(data.requestId())
                     .approvalId(data.responseId())
                     .build();
+            Notification savedNotification = notificationService.save(notification);
 
             MemberNotification memberNotification = MemberNotification.builder()
                     .member(receiverProxy)
-                    .notification(notification)
+                    .notification(savedNotification)
                     .build();
 
             memberNotificationService.save(memberNotification);
-            notificationService.save(notification);
 
             log.info("알림 저장 완료 for User ID: {}", receiverId);
 

--- a/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
+++ b/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
@@ -42,7 +42,7 @@ public class CommentNotificationListener {
                 // 이벤트 정보로 알림 데이터 생성
                 String message = String.format("'%s'님이 '%s' 게시글에 댓글을 남겼습니다:\n%s",
                         event.commenterNickname(), event.articleTitle(), truncateContent(event.commentContent()));
-                String link = String.format("/user/projects/%d/articles/%d", event.articleId(), event.commentId());
+                String link = String.format("/user/projects/%d/articles/%d", event.projectId(), event.articleId());
 
                 // NotificationData의 정적 팩토리 메서드 사용
                 NotificationData notificationData = NotificationData.forNewComment(

--- a/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
@@ -1,7 +1,14 @@
 package com.soda.notification.repository;
 
 import com.soda.notification.entity.MemberNotification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
+
+    @EntityGraph(attributePaths = {"notification"})
+    Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
+
 }

--- a/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
 
     @EntityGraph(attributePaths = {"notification"})
     Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
+    List<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -1,12 +1,16 @@
 package com.soda.notification.service;
 
+import com.soda.global.response.GeneralException;
 import com.soda.notification.entity.MemberNotification;
+import com.soda.notification.error.NotificationErrorCode;
 import com.soda.notification.repository.MemberNotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +24,17 @@ public class MemberNotificationService {
 
     public Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId, Pageable pageable) {
         return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId, pageable);
+    }
+
+    public MemberNotification findByIdOrThrow(Long id) {
+        return memberNotificationRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("MemberNotificationService: 알림을 찾을 수 없음 - ID: {}", id);
+                    return new GeneralException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+                });
+    }
+
+    public List<MemberNotification> findByMemberIdAndIsReadFalse(Long userId) {
+        return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId);
     }
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -4,6 +4,8 @@ import com.soda.notification.entity.MemberNotification;
 import com.soda.notification.repository.MemberNotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +16,9 @@ public class MemberNotificationService {
 
     public void save(MemberNotification memberNotification) {
         memberNotificationRepository.save(memberNotification);
+    }
+
+    public Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId, Pageable pageable) {
+        return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId, pageable);
     }
 }


### PR DESCRIPTION
# 요약

<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

사용자 알림 목록을 페이징하여 조회하는 API(`GET /notices`)를 구현합니다.

## ❗️ 선행 조건

**PR #274 ([Feature] 댓글/대댓글 생성 시 실시간 알림 기능 구현)**가 먼저 병합되어야 합니다.

## 주요 변경 사항

-   **API 구현:** `GET /notices` 엔드포인트 추가
-   **성능 최적화:** `@EntityGraph` 사용하여 N+1 문제 방지.
-   **읽음 처리 변경:** `MemberNotification`의 `isRead` 필드 제거
-  **알림 읽음은 해당 `MemberNotification`의 논리적 삭제(`isDeleted=true`)**로 처리할 예정 (삭제=읽음).
-   DTO(`NotificationResponse`), Service, Repository 관련 로직 구현.

## 기대 효과

-   효율적인 사용자 알림 목록 조회 기능 제공.
-   읽음 상태 관리 방식 단순화.

# 연관 이슈

Close #222

# Pull Request 체크리스트

## TODO

-   [ ] 최종 결과물을 확인했는가?
-   [ ] 의미 있는 커밋 메시지를 작성했는가?