### PR TITLE
[Feature]알림 읽음 기능 구현

### DIFF
--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -14,9 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
@@ -56,5 +54,26 @@ public class NotificationController {
         Page<NotificationResponse> notificationPage = notificationService.getNotifications(currentMemberId, pageable);
         log.info("사용자 알림 목록 조회 성공 - User ID: {}, 조회된 항목 수: {}", currentMemberId, notificationPage.getNumberOfElements());
         return ResponseEntity.ok(ApiResponseForm.success(notificationPage, "알림 목록 조회 성공"));
+    }
+
+    /**
+     * 특정 알림을 읽음 상태로 변경합니다.
+     * (이전에 수정한 코드와 동일한 형식 유지)
+     *
+     * @param memberNotificationId 읽음 처리할 MemberNotification의 ID
+     * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
+     */
+    @PostMapping("/{memberNotificationId}/read")
+    public ResponseEntity<ApiResponseForm<Void>> markNotificationAsRead(
+            @PathVariable Long memberNotificationId,
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("알림 읽음 처리 요청 - User ID: {}, MemberNotification ID: {}", currentMemberId, memberNotificationId);
+
+        notificationService.markAsRead(currentMemberId, memberNotificationId);
+        log.info("알림 읽음 처리 성공 - User ID: {}, MemberNotification ID: {}", currentMemberId, memberNotificationId);
+        return ResponseEntity.ok(ApiResponseForm.success(null, "알림 읽음 처리 성공"));
+
     }
 }

--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -76,4 +76,23 @@ public class NotificationController {
         return ResponseEntity.ok(ApiResponseForm.success(null, "알림 읽음 처리 성공"));
 
     }
+
+    /**
+     * 현재 로그인한 사용자의 모든 읽지 않은 알림을 읽음 상태로 변경합니다.
+     *
+     * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
+     */
+    @PatchMapping("/read-all")
+    public ResponseEntity<ApiResponseForm<Void>> markAllNotificationsAsRead(
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("사용자 모든 알림 읽음 처리 요청 - User ID: {}", currentMemberId);
+
+        notificationService.markAllAsReadIterative(currentMemberId);
+        log.info("사용자 모든 알림 읽음 처리 성공 - User ID: {}", currentMemberId);
+
+        return ResponseEntity.ok(ApiResponseForm.success(null, "모든 알림 읽음 처리 성공"));
+
+    }
 }

--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -63,7 +63,7 @@ public class NotificationController {
      * @param memberNotificationId 읽음 처리할 MemberNotification의 ID
      * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
      */
-    @PostMapping("/{memberNotificationId}/read")
+    @PatchMapping("/{memberNotificationId}/read")
     public ResponseEntity<ApiResponseForm<Void>> markNotificationAsRead(
             @PathVariable Long memberNotificationId,
             HttpServletRequest request) {

--- a/src/main/java/com/soda/notification/error/NotificationErrorCode.java
+++ b/src/main/java/com/soda/notification/error/NotificationErrorCode.java
@@ -9,7 +9,9 @@ public enum NotificationErrorCode implements ErrorCode { // <<< 클래스명 수
     USER_ID_NULL("2402", "SSE 구독 요청 - User ID가 null입니다.", HttpStatus.BAD_REQUEST),
     USER_ID_PARSE_FAILED("2403", "SSE 구독 요청 - 사용자 ID 추출에 실패했습니다.", HttpStatus.BAD_REQUEST),
 
-    SSE_CONNECTION_ERROR("2404", "SSE 구독 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    SSE_CONNECTION_ERROR("2404", "SSE 구독 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOTIFICATION_NOT_FOUND("2405", "해당 알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FORBIDDEN_ACCESS_NOTIFICATION("2406", "해당 알림에 접근할 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
+++ b/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
@@ -42,7 +42,7 @@ public class CommentNotificationListener {
                 // 이벤트 정보로 알림 데이터 생성
                 String message = String.format("'%s'님이 '%s' 게시글에 댓글을 남겼습니다:\n%s",
                         event.commenterNickname(), event.articleTitle(), truncateContent(event.commentContent()));
-                String link = String.format("/user/projects/%d/articles/%d", event.articleId(), event.commentId());
+                String link = String.format("/user/projects/%d/articles/%d", event.projectId(), event.articleId());
 
                 // NotificationData의 정적 팩토리 메서드 사용
                 NotificationData notificationData = NotificationData.forNewComment(

--- a/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
 
     @EntityGraph(attributePaths = {"notification"})
     Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
+    List<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -21,4 +21,8 @@ public class MemberNotificationService {
     public Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId, Pageable pageable) {
         return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId, pageable);
     }
+
+    public MemberNotification findById(Long id) {
+        return memberNotificationRepository.findById(id).orElse(null);
+    }
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -1,6 +1,8 @@
 package com.soda.notification.service;
 
+import com.soda.global.response.GeneralException;
 import com.soda.notification.entity.MemberNotification;
+import com.soda.notification.error.NotificationErrorCode;
 import com.soda.notification.repository.MemberNotificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +24,11 @@ public class MemberNotificationService {
         return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId, pageable);
     }
 
-    public MemberNotification findById(Long id) {
-        return memberNotificationRepository.findById(id).orElse(null);
+    public MemberNotification findByIdOrThrow(Long id) {
+        return memberNotificationRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("MemberNotificationService: 알림을 찾을 수 없음 - ID: {}", id);
+                    return new GeneralException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+                });
     }
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,5 +32,9 @@ public class MemberNotificationService {
                     log.warn("MemberNotificationService: 알림을 찾을 수 없음 - ID: {}", id);
                     return new GeneralException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
                 });
+    }
+
+    public List<MemberNotification> findByMemberIdAndIsReadFalse(Long userId) {
+        return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId);
     }
 }

--- a/src/main/java/com/soda/notification/service/NotificationService.java
+++ b/src/main/java/com/soda/notification/service/NotificationService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
@@ -66,5 +67,22 @@ public class NotificationService {
 
         log.info("사용자 알림 목록 조회 완료 - User ID: {}, Found: {} items", userId, responseDtoPage.getTotalElements());
         return responseDtoPage;
+    }
+
+    /**
+     * 사용자의 특정 알림을 읽음 상태로 변경합니다.
+     *
+     * @param userId              요청한 사용자의 ID
+     * @param memberNotificationId 읽음 처리할 MemberNotification의 ID
+     */
+    @Transactional
+    public void markAsRead(Long userId, Long memberNotificationId) {
+        log.debug("알림 읽음 처리 서비스 시작 - User ID: {}, MemberNotification ID: {}", userId, memberNotificationId);
+
+        MemberNotification memberNotification = memberNotificationService.findById(memberNotificationId);
+
+        memberNotification.Deleted();
+
+        log.debug("알림 읽음 처리 완료 및 저장 예정 - MemberNotification ID: {}", memberNotificationId);
     }
 }

--- a/src/main/java/com/soda/notification/service/NotificationService.java
+++ b/src/main/java/com/soda/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -94,5 +95,26 @@ public class NotificationService {
         memberNotification.Deleted();
 
         log.debug("알림 읽음 처리 완료 및 저장 예정 - MemberNotification ID: {}", memberNotificationId);
+    }
+
+    @Transactional
+    public void markAllAsReadIterative(Long userId) {
+        log.debug("사용자 모든 알림 읽음 처리 서비스 시작 (개별 업데이트) - User ID: {}", userId);
+
+        // 1. 읽지 않은 알림 조회
+        List<MemberNotification> unreadNotifications = memberNotificationService.findByMemberIdAndIsReadFalse(userId);
+
+        if (unreadNotifications.isEmpty()) {
+            log.info("읽지 않은 알림이 없습니다. User ID: {}", userId);
+            return;
+        }
+
+        // 2. 각 알림을 읽음 상태로 변경
+        for (MemberNotification notification : unreadNotifications) {
+            // 엔티티의 markAsRead 메서드가 readAt도 설정한다고 가정
+            notification.Deleted();
+        }
+
+        log.info("사용자 모든 알림 읽음 처리 완료 (개별 업데이트) - User ID: {}, 업데이트된 알림 수: {}", userId, unreadNotifications.size());
     }
 }


### PR DESCRIPTION
## ❗️ 선행 조건
이 PR은 알림 목록 조회 기능 및 관련 엔티티/서비스 구조를 포함하는 **PR #275** 의 변경 사항을 기반으로 합니다. 따라서 **PR #275가 먼저 `develop` 브랜치에 병합되어야 합니다.**
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

사용자 알림을 읽음 처리하는 API를 구현했습니다.
알림 읽음은 해당 `MemberNotification` 레코드의 논리적 삭제(`isDeleted = true`)로 처리합니다.
-   **읽음 API 구현:** `PATCH /notifications/{memberNotificationId}/read` 추가.


# 연관 이슈

Close #223

# Pull Request 체크리스트

## TODO

-   [ ] 최종 결과물을 확인했는가?
-   [ ] 의미 있는 커밋 메시지를 작성했는가?