### PR TITLE
[Feature] 알림 전체 읽음 기능 구현

### DIFF
--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -82,7 +82,7 @@ public class NotificationController {
      *
      * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
      */
-    @PostMapping("/read-all")
+    @PatchMapping("/read-all")
     public ResponseEntity<ApiResponseForm<Void>> markAllNotificationsAsRead(
             HttpServletRequest request) {
         Long currentMemberId = (Long) request.getAttribute("memberId");

--- a/src/main/java/com/soda/notification/controller/NotificationController.java
+++ b/src/main/java/com/soda/notification/controller/NotificationController.java
@@ -76,4 +76,23 @@ public class NotificationController {
         return ResponseEntity.ok(ApiResponseForm.success(null, "알림 읽음 처리 성공"));
 
     }
+
+    /**
+     * 현재 로그인한 사용자의 모든 읽지 않은 알림을 읽음 상태로 변경합니다.
+     *
+     * @return 성공 시 ApiResponseForm 형태의 200 OK 응답
+     */
+    @PostMapping("/read-all")
+    public ResponseEntity<ApiResponseForm<Void>> markAllNotificationsAsRead(
+            HttpServletRequest request) {
+        Long currentMemberId = (Long) request.getAttribute("memberId");
+
+        log.info("사용자 모든 알림 읽음 처리 요청 - User ID: {}", currentMemberId);
+
+        notificationService.markAllAsReadIterative(currentMemberId);
+        log.info("사용자 모든 알림 읽음 처리 성공 - User ID: {}", currentMemberId);
+
+        return ResponseEntity.ok(ApiResponseForm.success(null, "모든 알림 읽음 처리 성공"));
+
+    }
 }

--- a/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
+++ b/src/main/java/com/soda/notification/listener/CommentNotificationListener.java
@@ -42,7 +42,7 @@ public class CommentNotificationListener {
                 // 이벤트 정보로 알림 데이터 생성
                 String message = String.format("'%s'님이 '%s' 게시글에 댓글을 남겼습니다:\n%s",
                         event.commenterNickname(), event.articleTitle(), truncateContent(event.commentContent()));
-                String link = String.format("/user/projects/%d/articles/%d", event.articleId(), event.commentId());
+                String link = String.format("/user/projects/%d/articles/%d", event.projectId(), event.articleId());
 
                 // NotificationData의 정적 팩토리 메서드 사용
                 NotificationData notificationData = NotificationData.forNewComment(

--- a/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
+++ b/src/main/java/com/soda/notification/repository/MemberNotificationRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberNotificationRepository extends JpaRepository<MemberNotification, Long> {
 
     @EntityGraph(attributePaths = {"notification"})
     Page<MemberNotification> findByMemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
+    List<MemberNotification> findByMemberIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/com/soda/notification/service/MemberNotificationService.java
+++ b/src/main/java/com/soda/notification/service/MemberNotificationService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,5 +32,9 @@ public class MemberNotificationService {
                     log.warn("MemberNotificationService: 알림을 찾을 수 없음 - ID: {}", id);
                     return new GeneralException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
                 });
+    }
+
+    public List<MemberNotification> findByMemberIdAndIsReadFalse(Long userId) {
+        return memberNotificationRepository.findByMemberIdAndIsDeletedFalse(userId);
     }
 }

--- a/src/main/java/com/soda/notification/service/NotificationService.java
+++ b/src/main/java/com/soda/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -94,5 +95,26 @@ public class NotificationService {
         memberNotification.Deleted();
 
         log.debug("알림 읽음 처리 완료 및 저장 예정 - MemberNotification ID: {}", memberNotificationId);
+    }
+
+    @Transactional
+    public void markAllAsReadIterative(Long userId) {
+        log.debug("사용자 모든 알림 읽음 처리 서비스 시작 (개별 업데이트) - User ID: {}", userId);
+
+        // 1. 읽지 않은 알림 조회
+        List<MemberNotification> unreadNotifications = memberNotificationService.findByMemberIdAndIsReadFalse(userId);
+
+        if (unreadNotifications.isEmpty()) {
+            log.info("읽지 않은 알림이 없습니다. User ID: {}", userId);
+            return;
+        }
+
+        // 2. 각 알림을 읽음 상태로 변경
+        for (MemberNotification notification : unreadNotifications) {
+            // 엔티티의 markAsRead 메서드가 readAt도 설정한다고 가정
+            notification.Deleted();
+        }
+
+        log.info("사용자 모든 알림 읽음 처리 완료 (개별 업데이트) - User ID: {}, 업데이트된 알림 수: {}", userId, unreadNotifications.size());
     }
 }


### PR DESCRIPTION
## ❗️ 선행 조건
이 PR은 알림 읽음 기능 구현를 포함하는 **PR #276** 의 변경 사항을 기반으로 합니다. 따라서 **PR #276가 먼저 `develop` 브랜치에 병합되어야 합니다.**

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

사용자의 모든 읽지 않은 알림을 한 번에 읽음 처리하는 API를 구현했습니다.

-   **전체 읽음 API 추가:** `POST /notifications/read-all` 구현.
-   **서비스 로직:** 사용자의 읽지 않은 모든 알림 조회 후, 각 알림을 반복하며 논리적 삭제(`isDeleted=true`) 처리.
-   **링크 수정:** 댓글 알림 링크를 관련 게시글 경로로 변경.
-   **향후 개선:** 현재는 개별 업데이트 방식이나, 추후 알림 양 증가 시 성능 개선을 위해 **QueryDSL을 이용한 벌크 업데이트** 적용 예정.

# 연관 이슈

Close #224

# Pull Request 체크리스트

## TODO

-   [ ] 최종 결과물을 확인했는가?
-   [ ] 의미 있는 커밋 메시지를 작성했는가?