### PR TITLE
[Refact] Response(Approve) 생성 과정 레이어별로 책임 분리

### DIFF
--- a/src/main/java/com/soda/member/service/MemberService.java
+++ b/src/main/java/com/soda/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.soda.member.enums.MemberRole;
 import com.soda.member.enums.MemberStatus;
 import com.soda.member.error.MemberErrorCode;
 import com.soda.member.repository.MemberRepository;
+import com.soda.project.domain.error.ProjectErrorCode;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -344,5 +345,11 @@ public class MemberService {
                     log.warn("Member not found with ID: {}", userId);
                     return new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER);
                 });
+    }
+
+
+    public Member findWithProjectsById(Long memberId) {
+        return memberRepository.findWithProjectsById(memberId)
+                .orElseThrow(() -> new GeneralException(ProjectErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
@@ -1,4 +1,4 @@
-package com.soda.project.application.response;
+package com.soda.project.application.stage.request.response;
 
 import com.soda.member.entity.Member;
 import com.soda.member.service.MemberService;

--- a/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
@@ -1,0 +1,34 @@
+package com.soda.project.application.response;
+
+import com.soda.member.entity.Member;
+import com.soda.member.service.MemberService;
+import com.soda.project.application.stage.request.validator.RequestApproverValidator;
+import com.soda.project.application.validator.ProjectValidator;
+import com.soda.project.domain.stage.request.Request;
+import com.soda.project.domain.stage.request.RequestService;
+import com.soda.project.domain.stage.request.response.ResponseService;
+import com.soda.project.domain.stage.request.response.dto.RequestApproveRequest;
+import com.soda.project.domain.stage.request.response.dto.RequestApproveResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResponseFacade {
+
+    private final ResponseService responseService;
+    private final MemberService memberService;
+    private final RequestService requestService;
+
+    private final ProjectValidator projectValidator;
+    private final RequestApproverValidator requestApproverValidator;
+
+    public RequestApproveResponse approveRequest(Long memberId, Long requestId, RequestApproveRequest requestApproveRequest) {
+        Member member = memberService.getMemberWithProjectOrThrow(memberId);
+        Request request = requestService.getRequestOrThrow(requestId);
+        projectValidator.validateProjectAuthority(member, requestApproveRequest.getProjectId());
+        requestApproverValidator.validateApprover(member, request.getApprovers());
+
+        return responseService.approveRequest(member, request, requestApproveRequest);
+    }
+}

--- a/src/main/java/com/soda/project/application/stage/request/validator/RequestApproverValidator.java
+++ b/src/main/java/com/soda/project/application/stage/request/validator/RequestApproverValidator.java
@@ -1,0 +1,25 @@
+package com.soda.project.application.stage.request.validator;
+
+import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Member;
+import com.soda.project.domain.stage.request.ApproverDesignation;
+import com.soda.project.domain.stage.request.error.RequestErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RequestApproverValidator {
+
+    public void validateApprover(Member member, List<ApproverDesignation> approvers) {
+        List<Member> members = approvers.stream()
+                .map(ApproverDesignation::getMember)
+                .collect(Collectors.toList());
+        if (!members.contains(member)) {
+            throw new GeneralException(RequestErrorCode.USER_IS_NOT_APPROVER);
+        }
+    }
+}

--- a/src/main/java/com/soda/project/application/validator/ProjectValidator.java
+++ b/src/main/java/com/soda/project/application/validator/ProjectValidator.java
@@ -1,0 +1,31 @@
+package com.soda.project.application.validator;
+
+import com.soda.global.response.CommonErrorCode;
+import com.soda.global.response.GeneralException;
+import com.soda.member.entity.Member;
+import com.soda.member.enums.MemberProjectRole;
+import com.soda.member.enums.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectValidator {
+    public void validateProjectAuthority(Member member, Long projectId) {
+        if (!isCliInCurrentProject(projectId, member) && !isAdmin(member.getRole())) {
+            throw new GeneralException(CommonErrorCode.USER_NOT_IN_PROJECT_CLI);
+        }
+    }
+
+    private static boolean isCliInCurrentProject(Long projectId, Member member) {
+        return member.getMemberProjects().stream()
+                .anyMatch(mp ->
+                        mp.getProject().getId().equals(projectId) &&
+                                (mp.getRole() == MemberProjectRole.CLI_MANAGER || mp.getRole() == MemberProjectRole.CLI_PARTICIPANT)
+                );
+    }
+
+    private static boolean isAdmin(MemberRole memberRole) {
+        return memberRole == MemberRole.ADMIN;
+    }
+}

--- a/src/main/java/com/soda/project/domain/stage/request/Request.java
+++ b/src/main/java/com/soda/project/domain/stage/request/Request.java
@@ -8,6 +8,7 @@ import com.soda.project.domain.stage.request.enums.RequestStatus;
 import com.soda.project.domain.stage.request.file.RequestFile;
 import com.soda.project.domain.stage.request.link.RequestLink;
 import com.soda.project.domain.stage.request.response.Response;
+import com.soda.project.domain.stage.request.response.enums.ResponseStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -93,7 +94,7 @@ public class Request extends BaseEntity {
         markAsDeleted();
     }
 
-    public void approve() {
+    public void approved() {
         this.status = RequestStatus.APPROVED;
     }
 
@@ -114,5 +115,12 @@ public class Request extends BaseEntity {
 
     public void approving() {
         this.status = RequestStatus.APPROVING;
+    }
+
+    public boolean isOneRemainUntilApproved(Request request) {
+        return request.getResponses().stream()
+                .filter(response ->
+                        response.getStatus() == ResponseStatus.APPROVED && !response.getIsDeleted())
+                .count() == request.getApprovers().size() - 1;
     }
 }

--- a/src/main/java/com/soda/project/domain/stage/request/RequestService.java
+++ b/src/main/java/com/soda/project/domain/stage/request/RequestService.java
@@ -17,7 +17,6 @@ import com.soda.project.domain.stage.request.dto.*;
 import com.soda.project.domain.stage.request.enums.RequestStatus;
 import com.soda.project.domain.stage.request.error.RequestErrorCode;
 import com.soda.project.domain.stage.request.link.RequestLink;
-import com.soda.project.domain.stage.request.response.enums.ResponseStatus;
 import com.soda.project.infrastructure.ApproverDesignationRepository;
 import com.soda.project.infrastructure.RequestLinkRepository;
 import com.soda.project.infrastructure.RequestRepository;
@@ -135,19 +134,6 @@ public class RequestService {
         request.delete();
 
         return RequestDeleteResponse.fromEntity(request);
-    }
-
-    @Transactional
-    public void approve(Request request) {
-        if (isAllApproversApproved(request)) {
-            request.approve();
-        } else {
-            request.approving();
-        }
-    }
-
-    private static boolean isAllApproversApproved(Request request) {
-        return request.getResponses().stream().filter(response -> response.getStatus() == ResponseStatus.APPROVED && !response.getIsDeleted()).count() == request.getApprovers().size();
     }
 
     @Transactional

--- a/src/main/java/com/soda/project/domain/stage/request/response/Response.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/Response.java
@@ -49,6 +49,29 @@ public class Response extends BaseEntity {
         this.links = links;
     }
 
+    protected static Response createApprove(Member member, Request request, String comment, List<ResponseLink> links) {
+        Response approval = Response.builder()
+                .member(member)
+                .request(request)
+                .comment(comment)
+                .status(ResponseStatus.APPROVED)
+                .build();
+
+        approval.addLinks(links);
+
+        approval.approveApproverRequest(request);
+
+        return approval;
+    }
+
+    private void approveApproverRequest(Request request) {
+        if (request.isOneRemainUntilApproved(request)) {
+            request.approved();
+        } else {
+            request.approving();
+        }
+    }
+
     public void updateComment(String comment) {
         this.comment = comment;
     }

--- a/src/main/java/com/soda/project/domain/stage/request/response/Response.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/Response.java
@@ -49,15 +49,13 @@ public class Response extends BaseEntity {
         this.links = links;
     }
 
-    protected static Response createApprove(Member member, Request request, String comment, List<ResponseLink> links) {
+    protected static Response createApprove(Member member, Request request, String comment) {
         Response approval = Response.builder()
                 .member(member)
                 .request(request)
                 .comment(comment)
                 .status(ResponseStatus.APPROVED)
                 .build();
-
-        approval.addLinks(links);
 
         approval.approveApproverRequest(request);
 

--- a/src/main/java/com/soda/project/domain/stage/request/response/ResponseFactory.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/ResponseFactory.java
@@ -1,0 +1,35 @@
+package com.soda.project.domain.stage.request.response;
+
+import com.soda.common.link.dto.LinkUploadRequest;
+import com.soda.common.link.service.LinkService;
+import com.soda.member.entity.Member;
+import com.soda.project.domain.stage.request.Request;
+import com.soda.project.domain.stage.request.response.enums.ResponseStatus;
+import com.soda.project.domain.stage.request.response.link.ResponseLink;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ResponseFactory {
+
+    private final LinkService linkService;
+
+    public Response createApproveResponse(Member member, Request request, String comment, List<? extends LinkUploadRequest.LinkUploadDTO> linkContents) {
+        // 1. ID 없이 빈 Response 인스턴스 생성 (단순히 객체만)
+        Response dummyResponseForLink = Response.builder()
+                .member(member)
+                .request(request)
+                .comment(comment)
+                .status(ResponseStatus.APPROVED)
+                .build();
+
+        // 2. 해당 객체를 기반으로 링크 생성
+        List<ResponseLink> links = linkService.buildLinks("response", dummyResponseForLink, linkContents);
+
+        // 3. 링크를 포함한 최종 Response 생성
+        return Response.createApprove(member, request, comment, links);
+    }
+}

--- a/src/main/java/com/soda/project/domain/stage/request/response/ResponseFactory.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/ResponseFactory.java
@@ -4,7 +4,6 @@ import com.soda.common.link.dto.LinkUploadRequest;
 import com.soda.common.link.service.LinkService;
 import com.soda.member.entity.Member;
 import com.soda.project.domain.stage.request.Request;
-import com.soda.project.domain.stage.request.response.enums.ResponseStatus;
 import com.soda.project.domain.stage.request.response.link.ResponseLink;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,19 +16,14 @@ public class ResponseFactory {
 
     private final LinkService linkService;
 
-    public Response createApproveResponse(Member member, Request request, String comment, List<? extends LinkUploadRequest.LinkUploadDTO> linkContents) {
-        // 1. ID 없이 빈 Response 인스턴스 생성 (단순히 객체만)
-        Response dummyResponseForLink = Response.builder()
-                .member(member)
-                .request(request)
-                .comment(comment)
-                .status(ResponseStatus.APPROVED)
-                .build();
+    public Response createApproveResponse(Member member, Request request, String comment,
+                                          List<? extends LinkUploadRequest.LinkUploadDTO> linkContents) {
 
-        // 2. 해당 객체를 기반으로 링크 생성
-        List<ResponseLink> links = linkService.buildLinks("response", dummyResponseForLink, linkContents);
+        Response approval = Response.createApprove(member, request, comment);
 
-        // 3. 링크를 포함한 최종 Response 생성
-        return Response.createApprove(member, request, comment, links);
+        List<ResponseLink> links = linkService.buildLinks("response", approval, linkContents);
+        approval.addLinks(links);
+
+        return Response.createApprove(member, request, comment);
     }
 }

--- a/src/main/java/com/soda/project/domain/stage/request/response/ResponseService.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/ResponseService.java
@@ -42,12 +42,7 @@ public class ResponseService {
 
     @LoggableEntityAction(action = "CREATE", entityClass = Response.class)
     @Transactional
-    public RequestApproveResponse approveRequest(Long memberId, Long requestId, RequestApproveRequest requestApproveRequest) {
-        Member member = memberService.getMemberWithProjectOrThrow(memberId);
-        Request request = requestService.getRequestOrThrow(requestId);
-        validateProjectAuthority(member, requestApproveRequest.getProjectId());
-        validateApprover(member, request.getApprovers());
-
+    public RequestApproveResponse approveRequest(Member member, Request request, RequestApproveRequest requestApproveRequest) {
         Response approval = responseFactory.createApproveResponse(
                 member,
                 request,

--- a/src/main/java/com/soda/project/domain/stage/request/response/ResponseService.java
+++ b/src/main/java/com/soda/project/domain/stage/request/response/ResponseService.java
@@ -8,8 +8,7 @@ import com.soda.global.response.GeneralException;
 import com.soda.member.entity.Member;
 import com.soda.member.enums.MemberProjectRole;
 import com.soda.member.enums.MemberRole;
-import com.soda.member.repository.MemberRepository;
-import com.soda.project.domain.error.ProjectErrorCode;
+import com.soda.member.service.MemberService;
 import com.soda.project.domain.stage.request.ApproverDesignation;
 import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.RequestService;
@@ -30,26 +29,32 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ResponseService {
+    private final static String DOMAIN_TYPE = "response";
+
     private final RequestService requestService;
 
     private final ResponseRepository responseRepository;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final LinkService linkService;
+
+    private final ResponseFactory responseFactory;
 
 
     @LoggableEntityAction(action = "CREATE", entityClass = Response.class)
     @Transactional
     public RequestApproveResponse approveRequest(Long memberId, Long requestId, RequestApproveRequest requestApproveRequest) {
-        Member member = getMemberWithProjectOrThrow(memberId);
+        Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request request = requestService.getRequestOrThrow(requestId);
-
         validateProjectAuthority(member, requestApproveRequest.getProjectId());
         validateApprover(member, request.getApprovers());
 
-        Response approval = createResponse(member, request, requestApproveRequest.getComment(), requestApproveRequest.getLinks(), ResponseStatus.APPROVED);
+        Response approval = responseFactory.createApproveResponse(
+                member,
+                request,
+                requestApproveRequest.getComment(),
+                requestApproveRequest.getLinks()
+        );
         responseRepository.save(approval);
-
-        requestService.approve(request);
 
         return RequestApproveResponse.fromEntity(approval);
     }
@@ -131,9 +136,10 @@ public class ResponseService {
 
 
     // 분리한 메서드들
-    private Response createResponse(Member member, Request request, String comment, List<LinkUploadRequest.LinkUploadDTO> linkDTOs, ResponseStatus responseStatus) {
+    private Response createResponse(Member member, Request request, String comment,
+                                    List<LinkUploadRequest.LinkUploadDTO> linkDTOs, ResponseStatus responseStatus) {
         Response response = buildResponse(member, request, comment, responseStatus);
-        List<ResponseLink> links = linkService.buildLinks("response", response, linkDTOs);
+        List<ResponseLink> links = linkService.buildLinks(DOMAIN_TYPE, response, linkDTOs);
         response.addLinks(links);
         return response;
     }
@@ -147,23 +153,12 @@ public class ResponseService {
                 .build();
     }
 
-    private List<ResponseLink> buildResponseLinks(List<LinkUploadRequest.LinkUploadDTO> linkDTOs) {
-        if (linkDTOs == null) return List.of();
-
-        return linkDTOs.stream()
-                .map(dto -> ResponseLink.builder()
-                        .urlAddress(dto.getUrlAddress())
-                        .urlDescription(dto.getUrlDescription())
-                        .build())
-                .toList();
-    }
-
     private void updateResponseFields(ResponseUpdateRequest responseUpdateRequest, Response response) {
         if(responseUpdateRequest.getComment() != null) {
             response.updateComment(responseUpdateRequest.getComment());
         }
         if(responseUpdateRequest.getLinks() != null) {
-            response.addLinks(linkService.buildLinks("response", response, responseUpdateRequest.getLinks()));
+            response.addLinks(linkService.buildLinks(DOMAIN_TYPE, response, responseUpdateRequest.getLinks()));
         }
     }
 
@@ -178,8 +173,7 @@ public class ResponseService {
     }
 
     private Member getMemberWithProjectOrThrow(Long memberId) {
-        return memberRepository.findWithProjectsById(memberId)
-                .orElseThrow(() -> new GeneralException(ProjectErrorCode.MEMBER_NOT_FOUND));
+        return memberService.findWithProjectsById(memberId);
     }
 
     private void validateProjectAuthority(Member member, Long projectId) {

--- a/src/main/java/com/soda/project/interfaces/ResponseController.java
+++ b/src/main/java/com/soda/project/interfaces/ResponseController.java
@@ -5,8 +5,9 @@ import com.soda.common.file.service.FileService;
 import com.soda.common.link.dto.LinkDeleteResponse;
 import com.soda.common.link.service.LinkService;
 import com.soda.global.response.ApiResponseForm;
-import com.soda.project.domain.stage.request.response.dto.*;
+import com.soda.project.application.stage.request.response.ResponseFacade;
 import com.soda.project.domain.stage.request.response.ResponseService;
+import com.soda.project.domain.stage.request.response.dto.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,8 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 public class ResponseController {
+    private final ResponseFacade responseFacade;
+
     private final ResponseService responseService;
     private final FileService fileService;
     private final LinkService linkService;
@@ -26,7 +29,7 @@ public class ResponseController {
                                                             @PathVariable Long requestId,
                                                             HttpServletRequest request) {
         Long memberId = (Long) request.getAttribute("memberId");
-        RequestApproveResponse requestApproveResponse = responseService.approveRequest(memberId, requestId, requestApproveRequest);
+        RequestApproveResponse requestApproveResponse = responseFacade.approveRequest(memberId, requestId, requestApproveRequest);
         return ResponseEntity.ok(ApiResponseForm.success(requestApproveResponse));
     }
 


### PR DESCRIPTION
# 요약
- Response(Approve) 생성 과정 레이어별로 책임 분리

# 연관 이슈
#280 

# 확인해야할 사항
- 특정 승인요청에 대해 Approve하는 과정 즉, Approve상태의 Response를 생성하는 과정을 적절히 책임분리 해보았습니다.
- 기존 Service 메서드에서 Validation, 생성, 상태변경 모두를 담당했다면
변경 후에는 Application Layer에서 Validation을 담당하고, Domain Layer의 Service 메서드에서는 흐름만 제어하고, 엔티티에 생성, 상태변경을 위임했습니다. 
  - 이 때 Response를 생성할 때 ResponseLink도 생성해야하는데, 기존에 LinkService에서 전략패턴으로 ResponseLink를 생성하도록 구현했었는데 이를 활용하기 위해 ResponseFactory를 정의하고 여기서 Response와 ResponseLink의 생성을 담당하게 하였습니다. (Factory안에서 Response엔티티와 LinkService에 각각 생성 메세지를 보냄)
    - 기존에 구현했던 LinkService 전략패턴은 결국 Link의 생성을 Service에서 담당한다는 점에서 DDD의 원칙에 위배되는 것 같아 차후 리팩토링을 고려해보는 것도 좋을 것 같습니다.