### PR TITLE
[Fix] ProviderImpl에 Repository 빈 주입(final을 빼먹었었음)

### DIFF
--- a/src/main/java/com/soda/project/infrastructure/ResponseProviderImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/ResponseProviderImpl.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 public class ResponseProviderImpl implements ResponseProvider {
-    private ResponseRepository responseRepository;
+    private final ResponseRepository responseRepository;
 
     @Override
     public Response store(Response response) {


### PR DESCRIPTION

# 요약
- 승인요청에 대한 응답이 조회되지 않는 버그를 햐결하였음.


# 연관 이슈
#291 

# 확인해야할 사항
- ProviderImpl에 Repository 빈을 주입하여 해결하였습니다. (final을 빼먹었었어서 오류가 발생했었음)