### PR TITLE
[Fix] 로깅 엔티티액션 UPDATE_STATUS인 메서드 UPDATE로 변경

### DIFF
--- a/src/main/java/com/soda/project/application/ProjectFacade.java
+++ b/src/main/java/com/soda/project/application/ProjectFacade.java
@@ -202,7 +202,7 @@ public class ProjectFacade {
         projectService.deleteProject(project);
     }
 
-    @LoggableEntityAction(action = "UPDATE_STATUS", entityClass = Project.class)
+    @LoggableEntityAction(action = "UPDATE", entityClass = Project.class)
     @Transactional
     public ProjectStatusUpdateResponse updateProjectStatus(Long userId, Long projectId, ProjectStatusUpdateRequest request) {
         Member member = memberService.findMemberById(userId);


### PR DESCRIPTION

# 요약
- 로깅 엔티티액션 UPDATE_STATUS인 메서드 UPDATE로 변경

# 연관 이슈
#314 

# 확인해야할 사항
- 로깅을 하는 목적이 관리자가 데이터 변경이력을 확인하기 위함이므로 PATCH와 UPDATE를 구분할 필요는 없음
  - 따라서 따로 처리가 안돼있는 UPDATE_STATUS를 고수하고 처리로직을 추가하기보다는 애초에 UPDATE로 액션이 저장되어 로깅되게 수정하였음