### PR TITLE
[Bug] 회사 관련 생성,조회,수정,삭제 오류 관련 수정

### DIFF
--- a/src/main/java/com/soda/member/application/CompanyFacade.java
+++ b/src/main/java/com/soda/member/application/CompanyFacade.java
@@ -25,8 +25,8 @@ public class CompanyFacade {
         return companyService.createCompany(request);
     }
 
-    public List<CompanyResponse> getAllCompanies() {
-        return companyService.getAllCompanies();
+    public List<CompanyResponse> getAllCompanies(CompanyViewOption viewOption) {
+        return companyService.getAllCompanies(viewOption);
     }
 
     public CompanyResponse getCompanyById(Long id) {

--- a/src/main/java/com/soda/member/application/CompanyFacade.java
+++ b/src/main/java/com/soda/member/application/CompanyFacade.java
@@ -7,6 +7,8 @@ import com.soda.member.domain.company.CompanyStatsService;
 import com.soda.member.interfaces.dto.CompanyCreationTrend;
 import com.soda.member.interfaces.dto.company.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +25,6 @@ public class CompanyFacade {
     @LoggableEntityAction(action = "CREATE", entityClass = Company.class)
     public CompanyResponse createCompany(CompanyCreateRequest request) {
         return companyService.createCompany(request);
-    }
-
-    public List<CompanyResponse> getAllCompanies(CompanyViewOption viewOption) {
-        return companyService.getAllCompanies(viewOption);
     }
 
     public CompanyResponse getCompanyById(Long id) {
@@ -60,5 +58,10 @@ public class CompanyFacade {
 
     public List<CompanyCreationTrend> getCompanyCreationTrend(CompanyTrendSearchCondition condition) {
         return companyStatsService.getCompanyCreationTrend(condition);
+    }
+
+    public Page<CompanyResponse> getAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword,
+            Pageable pageable) {
+        return companyService.getAllCompaniesWithSearch(viewOption, searchKeyword, pageable);
     }
 }

--- a/src/main/java/com/soda/member/application/CompanyFacade.java
+++ b/src/main/java/com/soda/member/application/CompanyFacade.java
@@ -54,8 +54,8 @@ public class CompanyFacade {
         return companyService.restoreCompany(id);
     }
 
-    public List<MemberResponse> getCompanyMembers(Long companyId) {
-        return companyService.getCompanyMembers(companyId);
+    public List<MemberResponse> getCompanyMembers(Long companyId, MemberViewOption viewOption) {
+        return companyService.getCompanyMembers(companyId, viewOption);
     }
 
     public List<CompanyCreationTrend> getCompanyCreationTrend(CompanyTrendSearchCondition condition) {

--- a/src/main/java/com/soda/member/application/MemberFacade.java
+++ b/src/main/java/com/soda/member/application/MemberFacade.java
@@ -1,28 +1,26 @@
 package com.soda.member.application;
 
 import com.soda.global.response.GeneralException;
+import com.soda.member.application.validator.MemberValidator;
+import com.soda.member.domain.company.Company;
 import com.soda.member.domain.company.CompanyService;
 import com.soda.member.domain.member.Member;
+import com.soda.member.domain.member.MemberErrorCode;
 import com.soda.member.domain.member.MemberService;
 import com.soda.member.domain.member.MemberStatus;
-import com.soda.member.domain.company.Company;
 import com.soda.member.interfaces.dto.*;
 import com.soda.member.interfaces.dto.member.ChangePasswordRequest;
 import com.soda.member.interfaces.dto.member.MemberStatusResponse;
 import com.soda.member.interfaces.dto.member.admin.MemberDetailDto;
 import com.soda.member.interfaces.dto.member.admin.MemberListDto;
 import com.soda.member.interfaces.dto.member.admin.UpdateUserStatusRequestDto;
-import com.soda.member.application.validator.MemberValidator;
-import com.soda.member.domain.member.MemberErrorCode;
-import org.springframework.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -95,11 +93,11 @@ public class MemberFacade {
     public Page<MemberListDto> getAllUsers(Pageable pageable, String searchKeyword) {
         Page<Member> memberPage;
         if (StringUtils.hasText(searchKeyword)) {
-            memberPage = memberService.findByKeywordIncludingDeleted(searchKeyword, pageable);
+            memberPage = memberService.findByKeywordIncludingDeletedOrderByCreatedAtDesc(searchKeyword, pageable);
             log.info("관리자 사용자 목록 검색 조회: keyword={}, page={}, size={}", searchKeyword, pageable.getPageNumber(),
                     pageable.getPageSize());
         } else {
-            memberPage = memberService.findAll(pageable);
+            memberPage = memberService.findAllByOrderByCreatedAtDesc(pageable);
             log.info("관리자 전체 사용자 목록 조회: page={}, size={}", pageable.getPageNumber(), pageable.getPageSize());
         }
         return memberPage.map(MemberListDto::fromEntity);

--- a/src/main/java/com/soda/member/domain/company/CompanyProvider.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyProvider.java
@@ -11,17 +11,15 @@ public interface CompanyProvider {
 
         Optional<Company> findById(Long id);
 
-        List<Company> findAll();
+        List<Company> findAllByOrderByCreatedAtDesc();
 
-        Optional<Company> findByCompanyNumber(String companyNumber);
+        List<Company> findByIsDeletedFalseOrderByCreatedAtDesc();
 
-        List<Company> findByIsDeletedFalse();
+        List<Company> findByIsDeletedTrueOrderByCreatedAtDesc();
 
         Optional<Company> findByIdAndIsDeletedFalse(Long id);
 
         List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDateTime, LocalDateTime endDateTime);
 
         List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);
-
-        List<Company> findByIsDeletedTrue();
 }

--- a/src/main/java/com/soda/member/domain/company/CompanyProvider.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyProvider.java
@@ -22,4 +22,6 @@ public interface CompanyProvider {
         List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDateTime, LocalDateTime endDateTime);
 
         List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);
+
+        List<Company> findByIsDeletedTrue();
 }

--- a/src/main/java/com/soda/member/domain/company/CompanyProvider.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyProvider.java
@@ -1,6 +1,9 @@
 package com.soda.member.domain.company;
 
 import com.soda.member.interfaces.dto.CompanyCreationStatRaw;
+import com.soda.member.interfaces.dto.company.CompanyViewOption;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,15 +14,11 @@ public interface CompanyProvider {
 
         Optional<Company> findById(Long id);
 
-        List<Company> findAllByOrderByCreatedAtDesc();
-
-        List<Company> findByIsDeletedFalseOrderByCreatedAtDesc();
-
-        List<Company> findByIsDeletedTrueOrderByCreatedAtDesc();
-
         Optional<Company> findByIdAndIsDeletedFalse(Long id);
 
         List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDateTime, LocalDateTime endDateTime);
 
         List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);
+
+        Page<Company> findAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword, Pageable pageable);
 }

--- a/src/main/java/com/soda/member/domain/company/CompanyService.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyService.java
@@ -64,10 +64,10 @@ public class CompanyService {
         return CompanyResponse.fromEntity(companyProvider.store(company));
     }
 
-    public List<MemberResponse> getCompanyMembers(Long companyId) {
+    public List<MemberResponse> getCompanyMembers(Long companyId, MemberViewOption viewOption) {
         Company company = companyProvider.findByIdAndIsDeletedFalse(companyId)
                 .orElseThrow(() -> new GeneralException(CompanyErrorCode.NOT_FOUND_COMPANY));
-        return company.getMemberList().stream()
+        return viewOption.filterMembers(company.getMemberList()).stream()
                 .map(MemberResponse::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/soda/member/domain/company/CompanyService.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyService.java
@@ -4,6 +4,8 @@ import com.soda.global.response.GeneralException;
 import com.soda.member.interfaces.dto.company.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -22,13 +24,6 @@ public class CompanyService {
     public CompanyResponse createCompany(CompanyCreateRequest request) {
         Company company = Company.create(request);
         return CompanyResponse.fromEntity(companyProvider.store(company));
-    }
-
-    public List<CompanyResponse> getAllCompanies(CompanyViewOption viewOption) {
-        List<Company> companies = viewOption.getCompanies(companyProvider);
-        return companies.stream()
-                .map(CompanyResponse::fromEntity)
-                .collect(Collectors.toList());
     }
 
     public CompanyResponse getCompanyById(Long id) {
@@ -80,5 +75,11 @@ public class CompanyService {
         List<Company> companies = companyProvider.findByIdInAndIsDeletedFalse(companyIds);
         log.debug("ID 목록 {} 로 활성 회사 {}개 조회 완료", companyIds, companies.size());
         return companies;
+    }
+
+    public Page<CompanyResponse> getAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword,
+            Pageable pageable) {
+        Page<Company> companies = companyProvider.findAllCompaniesWithSearch(viewOption, searchKeyword, pageable);
+        return companies.map(CompanyResponse::fromEntity);
     }
 }

--- a/src/main/java/com/soda/member/domain/company/CompanyService.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyService.java
@@ -1,10 +1,7 @@
 package com.soda.member.domain.company;
 
 import com.soda.global.response.GeneralException;
-import com.soda.member.interfaces.dto.company.CompanyCreateRequest;
-import com.soda.member.interfaces.dto.company.CompanyResponse;
-import com.soda.member.interfaces.dto.company.CompanyUpdateRequest;
-import com.soda.member.interfaces.dto.company.MemberResponse;
+import com.soda.member.interfaces.dto.company.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,8 +24,24 @@ public class CompanyService {
         return CompanyResponse.fromEntity(companyProvider.store(company));
     }
 
-    public List<CompanyResponse> getAllCompanies() {
-        return companyProvider.findByIsDeletedFalse().stream()
+    public List<CompanyResponse> getAllCompanies(CompanyViewOption viewOption) {
+        List<Company> companies;
+        switch (viewOption) {
+            case ALL:
+                log.debug("모든 회사 조회 (삭제 포함)");
+                companies = companyProvider.findAll();
+                break;
+            case DELETED:
+                log.debug("삭제된 회사만 조회");
+                companies = companyProvider.findByIsDeletedTrue();
+                break;
+            case ACTIVE:
+            default:
+                log.debug("활성 회사만 조회 (삭제 안된 회사)");
+                companies = companyProvider.findByIsDeletedFalse();
+                break;
+        }
+        return companies.stream()
                 .map(CompanyResponse::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/soda/member/domain/company/CompanyService.java
+++ b/src/main/java/com/soda/member/domain/company/CompanyService.java
@@ -25,22 +25,7 @@ public class CompanyService {
     }
 
     public List<CompanyResponse> getAllCompanies(CompanyViewOption viewOption) {
-        List<Company> companies;
-        switch (viewOption) {
-            case ALL:
-                log.debug("모든 회사 조회 (삭제 포함)");
-                companies = companyProvider.findAll();
-                break;
-            case DELETED:
-                log.debug("삭제된 회사만 조회");
-                companies = companyProvider.findByIsDeletedTrue();
-                break;
-            case ACTIVE:
-            default:
-                log.debug("활성 회사만 조회 (삭제 안된 회사)");
-                companies = companyProvider.findByIsDeletedFalse();
-                break;
-        }
+        List<Company> companies = viewOption.getCompanies(companyProvider);
         return companies.stream()
                 .map(CompanyResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/com/soda/member/domain/member/MemberProvider.java
+++ b/src/main/java/com/soda/member/domain/member/MemberProvider.java
@@ -21,33 +21,19 @@ public interface MemberProvider {
 
     Optional<Member> findByEmailAndIsDeletedFalse(String email);
 
-    Optional<Member> findByNameAndEmailAndIsDeletedFalse(String name, String email);
-
     Optional<Member> findWithProjectsById(Long id);
 
     List<Member> findByIdInAndIsDeletedFalse(List<Long> ids);
 
     List<Member> findMembersByIdsAndCompany(List<Long> ids, Company company);
 
-    Page<Member> findAll(Pageable pageable);
-
     Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
-
-    Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
 
     Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
 
     boolean existsByAuthId(String authId);
 
     boolean existsByEmailAndIsDeletedFalse(String email);
-
-    Page<Member> findAllWithCompany(Pageable pageable);
-
-    Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable);
-
-    MemberDetailDto getMemberDetailWithCompany(Long userId);
-
-    List<Member> findMembersByCompany(Company company);
 
     Optional<Member> findByNameAndEmail(String name, String email);
 }

--- a/src/main/java/com/soda/member/domain/member/MemberProvider.java
+++ b/src/main/java/com/soda/member/domain/member/MemberProvider.java
@@ -31,7 +31,11 @@ public interface MemberProvider {
 
     Page<Member> findAll(Pageable pageable);
 
+    Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
     Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
+
+    Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
 
     boolean existsByAuthId(String authId);
 

--- a/src/main/java/com/soda/member/domain/member/MemberService.java
+++ b/src/main/java/com/soda/member/domain/member/MemberService.java
@@ -60,14 +60,6 @@ public class MemberService {
                 .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public FindAuthIdResponse findMaskedAuthId(FindAuthIdRequest request) {
-        Member member = memberProvider.findByNameAndEmailAndIsDeletedFalse(request.getName(), request.getEmail())
-                .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
-
-        String maskedAuthId = maskAuthId(member.getAuthId());
-        return new FindAuthIdResponse(maskedAuthId);
-    }
-
     public Member saveMember(Member member) {
         log.info("회원 정보 저장 완료: memberId={}", member.getId());
         return memberProvider.store(member);
@@ -120,24 +112,12 @@ public class MemberService {
         return memberProvider.findMembersByIdsAndCompany(ids, company);
     }
 
-    public List<Member> findMembersByCompany(Company company) {
-        return memberProvider.findMembersByCompany(company);
+    public Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable) {
+        return memberProvider.findAllByOrderByCreatedAtDesc(pageable);
     }
 
-    public Page<Member> findAll(Pageable pageable) {
-        return memberProvider.findAll(pageable);
-    }
-
-    public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
-        return memberProvider.findByKeywordIncludingDeleted(keyword, pageable);
-    }
-
-    public Page<Member> findAllWithCompany(Pageable pageable) {
-        return memberProvider.findAllWithCompany(pageable);
-    }
-
-    public Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable) {
-        return memberProvider.findByKeywordWithCompany(keyword, pageable);
+    public Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable) {
+        return memberProvider.findByKeywordIncludingDeletedOrderByCreatedAtDesc(keyword, pageable);
     }
 
     @Transactional
@@ -163,21 +143,6 @@ public class MemberService {
             return "*".repeat(length);
         }
         return authId.substring(0, 2) + "*".repeat(length - 4) + authId.substring(length - 2);
-    }
-
-    public Page<MemberListDto> getAllUsers(Pageable pageable, String searchKeyword) {
-        Page<Member> memberPage;
-
-        if (StringUtils.hasText(searchKeyword)) {
-            memberPage = findByKeywordIncludingDeleted(searchKeyword, pageable);
-            log.info("관리자 사용자 목록 검색 조회: keyword={}, page={}, size={}", searchKeyword, pageable.getPageNumber(),
-                    pageable.getPageSize());
-        } else {
-            memberPage = findAll(pageable);
-            log.info("관리자 전체 사용자 목록 조회: page={}, size={}", pageable.getPageNumber(), pageable.getPageSize());
-        }
-
-        return memberPage.map(MemberListDto::fromEntity);
     }
 
     public Member findByNameAndEmail(String name, String email) {

--- a/src/main/java/com/soda/member/domain/member/MemberService.java
+++ b/src/main/java/com/soda/member/domain/member/MemberService.java
@@ -187,7 +187,7 @@ public class MemberService {
 
     public void validateEmailExists(String email) {
         boolean isExists = memberProvider.existsByEmailAndIsDeletedFalse(email);
-        if (isExists) {
+        if (!isExists) {
             throw new GeneralException(MemberErrorCode.DUPLICATE_AUTH_ID);
         }
     }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
@@ -3,7 +3,10 @@ package com.soda.member.infrastructure.company;
 import com.soda.member.domain.company.Company;
 import com.soda.member.domain.company.CompanyProvider;
 import com.soda.member.interfaces.dto.CompanyCreationStatRaw;
+import com.soda.member.interfaces.dto.company.CompanyViewOption;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -25,18 +28,6 @@ public class CompanyProviderImpl implements CompanyProvider {
         return companyRepository.findById(id);
     }
 
-
-    @Override
-    public List<Company> findAllByOrderByCreatedAtDesc() {
-        return companyRepository.findAllByOrderByCreatedAtDesc();
-    }
-
-
-    @Override
-    public List<Company> findByIsDeletedFalseOrderByCreatedAtDesc() {
-        return companyRepository.findByIsDeletedFalseOrderByCreatedAtDesc();
-    }
-
     @Override
     public Optional<Company> findByIdAndIsDeletedFalse(Long id) {
         return companyRepository.findByIdAndIsDeletedFalse(id);
@@ -53,7 +44,8 @@ public class CompanyProviderImpl implements CompanyProvider {
     }
 
     @Override
-    public List<Company> findByIsDeletedTrueOrderByCreatedAtDesc() {
-        return companyRepository.findByIsDeletedTrueOrderByCreatedAtDesc();
+    public Page<Company> findAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword,
+            Pageable pageable) {
+        return companyRepository.findAllCompaniesWithSearch(viewOption, searchKeyword, pageable);
     }
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
@@ -25,19 +25,16 @@ public class CompanyProviderImpl implements CompanyProvider {
         return companyRepository.findById(id);
     }
 
-    @Override
-    public List<Company> findAll() {
-        return companyRepository.findAll();
-    }
 
     @Override
-    public Optional<Company> findByCompanyNumber(String companyNumber) {
-        return companyRepository.findByCompanyNumber(companyNumber);
+    public List<Company> findAllByOrderByCreatedAtDesc() {
+        return companyRepository.findAllByOrderByCreatedAtDesc();
     }
 
+
     @Override
-    public List<Company> findByIsDeletedFalse() {
-        return companyRepository.findByIsDeletedFalse();
+    public List<Company> findByIsDeletedFalseOrderByCreatedAtDesc() {
+        return companyRepository.findByIsDeletedFalseOrderByCreatedAtDesc();
     }
 
     @Override
@@ -56,7 +53,7 @@ public class CompanyProviderImpl implements CompanyProvider {
     }
 
     @Override
-    public List<Company> findByIsDeletedTrue() {
-        return companyRepository.findByIsDeletedTrue();
+    public List<Company> findByIsDeletedTrueOrderByCreatedAtDesc() {
+        return companyRepository.findByIsDeletedTrueOrderByCreatedAtDesc();
     }
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyProviderImpl.java
@@ -54,4 +54,9 @@ public class CompanyProviderImpl implements CompanyProvider {
     public List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds) {
         return companyRepository.findByIdInAndIsDeletedFalse(companyIds);
     }
+
+    @Override
+    public List<Company> findByIsDeletedTrue() {
+        return companyRepository.findByIsDeletedTrue();
+    }
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
@@ -11,17 +11,6 @@ import java.util.Optional;
 public interface CompanyRepository extends JpaRepository<Company, Long>, CompanyRepositoryCustom {
     Optional<Company> findByIdAndIsDeletedFalse(Long companyId);
 
-    List<Company> findByIsDeletedFalse();
-
-    List<Company> findByIsDeletedFalseOrderByCreatedAtDesc();
-
-    List<Company> findAllByOrderByCreatedAtDesc();
-
-    List<Company> findByIsDeletedTrueOrderByCreatedAtDesc();
-
-    Optional<Company> findByCompanyNumber(String companyNumber);
-
     List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);
 
-    List<Company> findByIsDeletedTrue();
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
@@ -13,6 +13,12 @@ public interface CompanyRepository extends JpaRepository<Company, Long>, Company
 
     List<Company> findByIsDeletedFalse();
 
+    List<Company> findByIsDeletedFalseOrderByCreatedAtDesc();
+
+    List<Company> findAllByOrderByCreatedAtDesc();
+
+    List<Company> findByIsDeletedTrueOrderByCreatedAtDesc();
+
     Optional<Company> findByCompanyNumber(String companyNumber);
 
     List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyRepository.java
@@ -16,4 +16,6 @@ public interface CompanyRepository extends JpaRepository<Company, Long>, Company
     Optional<Company> findByCompanyNumber(String companyNumber);
 
     List<Company> findByIdInAndIsDeletedFalse(List<Long> companyIds);
+
+    List<Company> findByIsDeletedTrue();
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyRepositoryCustom.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyRepositoryCustom.java
@@ -1,10 +1,16 @@
 package com.soda.member.infrastructure.company;
 
+import com.soda.member.domain.company.Company;
 import com.soda.member.interfaces.dto.CompanyCreationStatRaw;
+import com.soda.member.interfaces.dto.company.CompanyViewOption;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CompanyRepositoryCustom {
     List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDate, LocalDateTime endDate);
+
+    Page<Company> findAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword, Pageable pageable);
 }

--- a/src/main/java/com/soda/member/infrastructure/company/CompanyRepositoryImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/company/CompanyRepositoryImpl.java
@@ -1,45 +1,96 @@
 package com.soda.member.infrastructure.company;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soda.member.domain.company.Company;
 import com.soda.member.domain.company.QCompany;
 import com.soda.member.interfaces.dto.CompanyCreationStatRaw;
+import com.soda.member.interfaces.dto.company.CompanyViewOption;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.soda.member.domain.company.QCompany.company;
+
+@Repository
 @RequiredArgsConstructor
 public class CompanyRepositoryImpl implements CompanyRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
+        private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDate, LocalDateTime endDate) {
-        QCompany company = QCompany.company;
+        @Override
+        public List<CompanyCreationStatRaw> countCompaniesByDayRaw(LocalDateTime startDate, LocalDateTime endDate) {
+                QCompany company = QCompany.company;
 
-        NumberExpression<Integer> year = company.createdAt.year();
-        NumberExpression<Integer> month = company.createdAt.month();
-        NumberExpression<Integer> week = company.createdAt.week();
-        NumberExpression<Integer> day = company.createdAt.dayOfMonth();
+                NumberExpression<Integer> year = company.createdAt.year();
+                NumberExpression<Integer> month = company.createdAt.month();
+                NumberExpression<Integer> week = company.createdAt.week();
+                NumberExpression<Integer> day = company.createdAt.dayOfMonth();
 
-        return queryFactory
-                .select(Projections.constructor(CompanyCreationStatRaw.class,
-                        year,
-                        month,
-                        week,
-                        day,
-                        company.count().as("count")
-                ))
-                .from(company)
-                .where(
-                        company.createdAt.goe(startDate),
-                        company.createdAt.lt(endDate),
-                        company.isDeleted.isFalse()
-                )
-                .groupBy(year, month, week, day)
-                .orderBy(year.asc(), month.asc(), week.asc(), day.asc())
-                .fetch();
-    }
+                return queryFactory
+                                .select(Projections.constructor(CompanyCreationStatRaw.class,
+                                                year,
+                                                month,
+                                                week,
+                                                day,
+                                                company.count().as("count")))
+                                .from(company)
+                                .where(
+                                                company.createdAt.goe(startDate),
+                                                company.createdAt.lt(endDate),
+                                                company.isDeleted.isFalse())
+                                .groupBy(year, month, week, day)
+                                .orderBy(year.asc(), month.asc(), week.asc(), day.asc())
+                                .fetch();
+        }
+
+        @Override
+        public Page<Company> findAllCompaniesWithSearch(CompanyViewOption viewOption, String searchKeyword,
+                        Pageable pageable) {
+                BooleanExpression whereClause = createWhereClause(viewOption, searchKeyword);
+
+                List<Company> companies = queryFactory
+                                .selectFrom(company)
+                                .where(whereClause)
+                                .orderBy(company.createdAt.desc())
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch();
+
+                Long total = queryFactory
+                                .select(company.count())
+                                .from(company)
+                                .where(whereClause)
+                                .fetchOne();
+
+                return new PageImpl<>(companies, pageable, total != null ? total : 0L);
+        }
+
+        private BooleanExpression createWhereClause(CompanyViewOption viewOption, String searchKeyword) {
+                BooleanExpression baseClause = null;
+
+                switch (viewOption) {
+                        case ACTIVE -> baseClause = company.isDeleted.isFalse();
+                        case DELETED -> baseClause = company.isDeleted.isTrue();
+                        case ALL -> baseClause = null;
+                }
+
+                if (StringUtils.hasText(searchKeyword)) {
+                        BooleanExpression searchClause = company.name.containsIgnoreCase(searchKeyword)
+                                        .or(company.companyNumber.containsIgnoreCase(searchKeyword))
+                                        .or(company.ownerName.containsIgnoreCase(searchKeyword));
+
+                        return baseClause != null ? baseClause.and(searchClause) : searchClause;
+                }
+
+                return baseClause;
+        }
 }

--- a/src/main/java/com/soda/member/infrastructure/member/MemberProviderImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberProviderImpl.java
@@ -112,8 +112,18 @@ public class MemberProviderImpl implements MemberProvider {
     }
 
     @Override
+    public Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable) {
+        return memberRepository.findAllByOrderByCreatedAtDesc(pageable);
+    }
+
+    @Override
     public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
         return memberRepository.findByKeywordIncludingDeleted(keyword, pageable);
+    }
+
+    @Override
+    public Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable) {
+        return memberRepository.findByKeywordIncludingDeletedOrderByCreatedAtDesc(keyword, pageable);
     }
 
     @Override

--- a/src/main/java/com/soda/member/infrastructure/member/MemberProviderImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberProviderImpl.java
@@ -57,11 +57,6 @@ public class MemberProviderImpl implements MemberProvider {
     }
 
     @Override
-    public Optional<Member> findByNameAndEmailAndIsDeletedFalse(String name, String email) {
-        return memberRepository.findByNameAndEmailAndIsDeletedFalse(name, email);
-    }
-
-    @Override
     public Optional<Member> findWithProjectsById(Long id) {
         return memberRepository.findWithProjectsById(id);
     }
@@ -107,18 +102,8 @@ public class MemberProviderImpl implements MemberProvider {
     }
 
     @Override
-    public Page<Member> findAll(Pageable pageable) {
-        return memberRepository.findAll(pageable);
-    }
-
-    @Override
     public Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable) {
         return memberRepository.findAllByOrderByCreatedAtDesc(pageable);
-    }
-
-    @Override
-    public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
-        return memberRepository.findByKeywordIncludingDeleted(keyword, pageable);
     }
 
     @Override
@@ -134,31 +119,6 @@ public class MemberProviderImpl implements MemberProvider {
     @Override
     public boolean existsByEmailAndIsDeletedFalse(String email) {
         return memberRepository.existsByEmailAndIsDeletedFalse(email);
-    }
-
-    @Override
-    public Page<Member> findAllWithCompany(Pageable pageable) {
-        return memberRepository.findAllWithCompany(pageable);
-    }
-
-    @Override
-    public Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable) {
-        return memberRepository.findByKeywordWithCompany(keyword, pageable);
-    }
-
-    @Override
-    public MemberDetailDto getMemberDetailWithCompany(Long userId) {
-        Member member = findById(userId)
-                .orElseThrow(() -> new GeneralException(MemberErrorCode.NOT_FOUND_MEMBER));
-        return MemberDetailDto.fromEntity(member);
-    }
-
-    @Override
-    public List<Member> findMembersByCompany(Company company) {
-        if (company == null || company.getId() == null) {
-            throw new GeneralException(CommonErrorCode.BAD_REQUEST);
-        }
-        return memberRepository.findByCompanyAndIsDeletedFalse(company);
     }
 
     @Override

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepository.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepository.java
@@ -20,15 +20,11 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Optional<Member> findByIdAndIsDeletedFalse(Long memberId);
 
-    Optional<Member> findByEmail(String email);
-
     Optional<Member> findWithProjectsById(Long id);
 
     boolean existsByEmailAndIsDeletedFalse(String email);
 
     List<Member> findByIdInAndIsDeletedFalse(List<Long> memberIds);
-
-    List<Member> findByIdIn(List<Long> ids);
 
     Optional<Member> findByNameAndEmailAndIsDeletedFalse(String name, String email);
 
@@ -36,17 +32,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Optional<Member> findByEmailAndIsDeletedFalse(String email);
 
-    List<Member> findByCompanyAndIsDeletedFalse(Company company);
-
-    Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
-
     Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
-
-    Page<Member> findAllWithCompany(Pageable pageable);
 
     Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable);
-
-    Optional<Member> findByIdWithCompany(Long id);
 }

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepository.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepository.java
@@ -1,7 +1,7 @@
 package com.soda.member.infrastructure.member;
 
-import com.soda.member.domain.member.Member;
 import com.soda.member.domain.company.Company;
+import com.soda.member.domain.member.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,7 +40,11 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
 
+    Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
+
     Page<Member> findAllWithCompany(Pageable pageable);
+
+    Page<Member> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable);
 

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryCustom.java
@@ -7,13 +7,5 @@ import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface MemberRepositoryCustom {
-    Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
-
     Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
-
-    Page<Member> findAllWithCompany(Pageable pageable);
-
-    Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable);
-
-    Optional<Member> findByIdWithCompany(Long id);
 }

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryCustom.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 public interface MemberRepositoryCustom {
     Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable);
 
+    Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable);
+
     Page<Member> findAllWithCompany(Pageable pageable);
 
     Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable);

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryImpl.java
@@ -54,6 +54,28 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         }
 
         @Override
+        public Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable) {
+                QMember member = QMember.member;
+                BooleanExpression keywordCondition = createKeywordCondition(member, keyword);
+
+                List<Member> members = queryFactory
+                                .selectFrom(member)
+                                .where(keywordCondition)
+                                .orderBy(member.createdAt.desc())
+                                .offset(pageable.getOffset())
+                                .limit(pageable.getPageSize())
+                                .fetch();
+
+                Long total = queryFactory
+                                .select(member.count())
+                                .from(member)
+                                .where(keywordCondition)
+                                .fetchOne();
+
+                return PageableExecutionUtils.getPage(members, pageable, () -> total);
+        }
+
+        @Override
         public Page<Member> findAllWithCompany(Pageable pageable) {
                 QMember member = QMember.member;
 
@@ -102,6 +124,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 }
                 return member.name.containsIgnoreCase(keyword)
                                 .or(member.email.containsIgnoreCase(keyword))
-                                .or(member.authId.containsIgnoreCase(keyword));
+                                .or(member.authId.containsIgnoreCase(keyword))
+                        .or(member.company.name.containsIgnoreCase(keyword));
         }
 }

--- a/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/soda/member/infrastructure/member/MemberRepositoryImpl.java
@@ -19,39 +19,6 @@ import java.util.Optional;
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
         private final JPAQueryFactory queryFactory;
 
-        @Override
-        public Optional<Member> findByIdWithCompany(Long id) {
-                QMember member = QMember.member;
-
-                Member foundMember = queryFactory
-                                .selectFrom(member)
-                                .leftJoin(member.company).fetchJoin()
-                                .where(member.id.eq(id))
-                                .fetchOne();
-
-                return Optional.ofNullable(foundMember);
-        }
-
-        @Override
-        public Page<Member> findByKeywordIncludingDeleted(String keyword, Pageable pageable) {
-                QMember member = QMember.member;
-                BooleanExpression keywordCondition = createKeywordCondition(member, keyword);
-
-                List<Member> members = queryFactory
-                                .selectFrom(member)
-                                .where(keywordCondition)
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch();
-
-                Long total = queryFactory
-                                .select(member.count())
-                                .from(member)
-                                .where(keywordCondition)
-                                .fetchOne();
-
-                return PageableExecutionUtils.getPage(members, pageable, () -> total);
-        }
 
         @Override
         public Page<Member> findByKeywordIncludingDeletedOrderByCreatedAtDesc(String keyword, Pageable pageable) {
@@ -70,49 +37,6 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                                 .select(member.count())
                                 .from(member)
                                 .where(keywordCondition)
-                                .fetchOne();
-
-                return PageableExecutionUtils.getPage(members, pageable, () -> total);
-        }
-
-        @Override
-        public Page<Member> findAllWithCompany(Pageable pageable) {
-                QMember member = QMember.member;
-
-                List<Member> members = queryFactory
-                                .selectFrom(member)
-                                .leftJoin(member.company).fetchJoin()
-                                .where(member.isDeleted.eq(false))
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch();
-
-                Long total = queryFactory
-                                .select(member.count())
-                                .from(member)
-                                .where(member.isDeleted.eq(false))
-                                .fetchOne();
-
-                return PageableExecutionUtils.getPage(members, pageable, () -> total);
-        }
-
-        @Override
-        public Page<Member> findByKeywordWithCompany(String keyword, Pageable pageable) {
-                QMember member = QMember.member;
-                BooleanExpression keywordCondition = createKeywordCondition(member, keyword);
-
-                List<Member> members = queryFactory
-                                .selectFrom(member)
-                                .leftJoin(member.company).fetchJoin()
-                                .where(member.isDeleted.eq(false).and(keywordCondition))
-                                .offset(pageable.getOffset())
-                                .limit(pageable.getPageSize())
-                                .fetch();
-
-                Long total = queryFactory
-                                .select(member.count())
-                                .from(member)
-                                .where(member.isDeleted.eq(false).and(keywordCondition))
                                 .fetchOne();
 
                 return PageableExecutionUtils.getPage(members, pageable, () -> total);

--- a/src/main/java/com/soda/member/interfaces/AuthController.java
+++ b/src/main/java/com/soda/member/interfaces/AuthController.java
@@ -9,15 +9,11 @@ import com.soda.member.interfaces.dto.member.LoginRequest;
 import com.soda.member.interfaces.dto.member.LoginResponse;
 import com.soda.member.interfaces.dto.member.admin.CreateMemberRequest;
 import com.soda.member.domain.AuthService;
-import com.soda.member.domain.member.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -26,7 +22,6 @@ import java.io.IOException;
 public class AuthController {
 
     private final AuthService authService;
-    private final MemberService memberService;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponseForm<Void>> signup(@RequestBody CreateMemberRequest requestDto) {
@@ -68,6 +63,18 @@ public class AuthController {
     public ResponseEntity<ApiResponseForm<Void>> logout(HttpServletResponse response) {
         authService.logout(response);
         return ResponseEntity.ok(ApiResponseForm.success(null, "로그아웃 성공"));
+    }
+
+    @GetMapping("/check-id")
+    public ResponseEntity<ApiResponseForm<Boolean>> checkIdAvailability(@RequestParam String authId) {
+        boolean isAvailable = authService.checkIdAvailability(authId);
+        return ResponseEntity.ok(ApiResponseForm.success(isAvailable, "아이디 중복 확인 성공"));
+    }
+
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponseForm<Boolean>> checkEmailAvailability(@RequestParam String email) {
+        boolean isAvailable = authService.checkEmailAvailability(email);
+        return ResponseEntity.ok(ApiResponseForm.success(isAvailable, "이메일 중복 확인 성공"));
     }
 
 }

--- a/src/main/java/com/soda/member/interfaces/CompanyController.java
+++ b/src/main/java/com/soda/member/interfaces/CompanyController.java
@@ -27,8 +27,9 @@ public class CompanyController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponseForm<List<CompanyResponse>>> getAllCompanies() {
-        List<CompanyResponse> companies = companyFacade.getAllCompanies();
+    public ResponseEntity<ApiResponseForm<List<CompanyResponse>>> getAllCompanies(
+            @RequestParam(name = "view", defaultValue = "ACTIVE") CompanyViewOption viewOption) {
+        List<CompanyResponse> companies = companyFacade.getAllCompanies(viewOption);
         return ResponseEntity.ok(ApiResponseForm.success(companies, "회사리스트 조회 성공"));
     }
 

--- a/src/main/java/com/soda/member/interfaces/CompanyController.java
+++ b/src/main/java/com/soda/member/interfaces/CompanyController.java
@@ -6,6 +6,8 @@ import com.soda.member.interfaces.dto.company.*;
 import com.soda.member.application.CompanyFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,10 +29,12 @@ public class CompanyController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponseForm<List<CompanyResponse>>> getAllCompanies(
-            @RequestParam(name = "view", defaultValue = "ACTIVE") CompanyViewOption viewOption) {
-        List<CompanyResponse> companies = companyFacade.getAllCompanies(viewOption);
-        return ResponseEntity.ok(ApiResponseForm.success(companies, "회사리스트 조회 성공"));
+    public ResponseEntity<ApiResponseForm<Page<CompanyResponse>>> getAllCompanies(
+            @RequestParam(name = "view", defaultValue = "ACTIVE") CompanyViewOption viewOption,
+            @RequestParam(required = false) String searchKeyword,
+            Pageable pageable) {
+        Page<CompanyResponse> companies = companyFacade.getAllCompaniesWithSearch(viewOption, searchKeyword, pageable);
+        return ResponseEntity.ok(ApiResponseForm.success(companies, "회사 리스트 조회 성공"));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/soda/member/interfaces/CompanyController.java
+++ b/src/main/java/com/soda/member/interfaces/CompanyController.java
@@ -60,8 +60,10 @@ public class CompanyController {
     }
 
     @GetMapping("/{id}/members")
-    public ResponseEntity<ApiResponseForm<List<MemberResponse>>> getCompanyMembers(@PathVariable Long id) {
-        List<MemberResponse> members = companyFacade.getCompanyMembers(id);
+    public ResponseEntity<ApiResponseForm<List<MemberResponse>>> getCompanyMembers(
+            @PathVariable Long id,
+            @RequestParam(name = "view", defaultValue = "ACTIVE") MemberViewOption viewOption) {
+        List<MemberResponse> members = companyFacade.getCompanyMembers(id, viewOption);
         return ResponseEntity.ok(ApiResponseForm.success(members, "회사 멤버 정보 조회 성공"));
     }
 

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyResponse.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyResponse.java
@@ -1,11 +1,13 @@
 package com.soda.member.interfaces.dto.company;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.soda.member.domain.company.Company;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CompanyResponse {
     private Long id;
     private String name;
@@ -14,6 +16,7 @@ public class CompanyResponse {
     private String address;
     private String detailAddress;
     private String ownerName;
+    private Boolean isDeleted;
 
     public static CompanyResponse fromEntity(Company company) {
         if (company == null) {
@@ -27,6 +30,7 @@ public class CompanyResponse {
                 .address(company.getAddress())
                 .detailAddress(company.getDetailAddress())
                 .ownerName(company.getOwnerName())
+                .isDeleted(company.getIsDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyUpdateRequest.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyUpdateRequest.java
@@ -8,13 +8,14 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CompanyUpdateRequest {
-    @Size(max = 100, message = "회사명은 100자를 초과할 수 없습니다.")
+    @Size(max = 50, message = "회사명은 50자를 초과할 수 없습니다.")
     private String name;
 
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
     private String phoneNumber;
 
-    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "올바른 사업자등록번호 형식이 아닙니다.")
+    @Size(max = 20, message = "사업자등록번호은 20자를 초과할 수 없습니다.")
+//    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "올바른 사업자등록번호 형식이 아닙니다.")
     private String companyNumber;
 
     @Size(max = 200, message = "주소는 200자를 초과할 수 없습니다.")
@@ -23,6 +24,6 @@ public class CompanyUpdateRequest {
     @Size(max = 100, message = "상세주소는 100자를 초과할 수 없습니다.")
     private String detailAddress;
 
-    @Size(max = 50, message = "대표자명은 50자를 초과할 수 없습니다.")
+    @Size(max = 10, message = "대표자명은 10자를 초과할 수 없습니다.")
     private String ownerName;
 }

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
@@ -1,0 +1,7 @@
+package com.soda.member.interfaces.dto.company;
+
+public enum CompanyViewOption {
+    ACTIVE, // 삭제 안된 회사 (기본값)
+    ALL,    // 모든 회사 (삭제된 회사 포함)
+    DELETED // 삭제된 회사만
+}

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
@@ -7,11 +7,10 @@ import java.util.List;
 import java.util.function.Function;
 
 public enum CompanyViewOption {
-    ACTIVE(provider -> provider.findByIsDeletedFalse()),
-    ALL(provider -> provider.findAll()),
-    DELETED(provider -> provider.findByIsDeletedTrue());
+    ACTIVE(CompanyProvider::findByIsDeletedFalseOrderByCreatedAtDesc),
+    ALL(CompanyProvider::findAllByOrderByCreatedAtDesc),
+    DELETED(CompanyProvider::findByIsDeletedTrueOrderByCreatedAtDesc);
 
-    // 방법 1: Function<CompanyProvider, List<Company>> 사용
     private final Function<CompanyProvider, List<Company>> retrievalFunction;
 
     CompanyViewOption(Function<CompanyProvider, List<Company>> retrievalFunction) {

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
@@ -1,23 +1,7 @@
 package com.soda.member.interfaces.dto.company;
 
-import com.soda.member.domain.company.Company;
-import com.soda.member.domain.company.CompanyProvider;
-
-import java.util.List;
-import java.util.function.Function;
-
 public enum CompanyViewOption {
-    ACTIVE(CompanyProvider::findByIsDeletedFalseOrderByCreatedAtDesc),
-    ALL(CompanyProvider::findAllByOrderByCreatedAtDesc),
-    DELETED(CompanyProvider::findByIsDeletedTrueOrderByCreatedAtDesc);
-
-    private final Function<CompanyProvider, List<Company>> retrievalFunction;
-
-    CompanyViewOption(Function<CompanyProvider, List<Company>> retrievalFunction) {
-        this.retrievalFunction = retrievalFunction;
-    }
-
-    public List<Company> getCompanies(CompanyProvider companyProvider) {
-        return this.retrievalFunction.apply(companyProvider);
-    }
+    ACTIVE, // 삭제되지 않은 회사
+    ALL, // 모든 회사
+    DELETED // 삭제된 회사
 }

--- a/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/CompanyViewOption.java
@@ -1,7 +1,24 @@
 package com.soda.member.interfaces.dto.company;
 
+import com.soda.member.domain.company.Company;
+import com.soda.member.domain.company.CompanyProvider;
+
+import java.util.List;
+import java.util.function.Function;
+
 public enum CompanyViewOption {
-    ACTIVE, // 삭제 안된 회사 (기본값)
-    ALL,    // 모든 회사 (삭제된 회사 포함)
-    DELETED // 삭제된 회사만
+    ACTIVE(provider -> provider.findByIsDeletedFalse()),
+    ALL(provider -> provider.findAll()),
+    DELETED(provider -> provider.findByIsDeletedTrue());
+
+    // 방법 1: Function<CompanyProvider, List<Company>> 사용
+    private final Function<CompanyProvider, List<Company>> retrievalFunction;
+
+    CompanyViewOption(Function<CompanyProvider, List<Company>> retrievalFunction) {
+        this.retrievalFunction = retrievalFunction;
+    }
+
+    public List<Company> getCompanies(CompanyProvider companyProvider) {
+        return this.retrievalFunction.apply(companyProvider);
+    }
 }

--- a/src/main/java/com/soda/member/interfaces/dto/company/MemberResponse.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/MemberResponse.java
@@ -1,27 +1,39 @@
 package com.soda.member.interfaces.dto.company;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.soda.member.domain.member.Member;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemberResponse {
     private Long id;
     private String authId;
     private String name;
+    private String email;
     private String position;
     private String phoneNumber;
     private String role;
+    private String CompanyName;
+    private Boolean isDeleted;
 
     public static MemberResponse fromEntity(Member member) {
+        String companyNameResult = null;
+        if (member.getCompany() != null) {
+            companyNameResult = member.getCompany().getName();
+        }
         return MemberResponse.builder()
                 .id(member.getId())
                 .authId(member.getAuthId())
                 .name(member.getName())
+                .email(member.getEmail())
                 .position(member.getPosition())
                 .phoneNumber(member.getPhoneNumber())
                 .role(member.getRole().toString())
+                .CompanyName(companyNameResult)
+                .isDeleted(member.getIsDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/soda/member/interfaces/dto/company/MemberViewOption.java
+++ b/src/main/java/com/soda/member/interfaces/dto/company/MemberViewOption.java
@@ -1,0 +1,39 @@
+package com.soda.member.interfaces.dto.company;
+
+import com.soda.member.domain.member.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberViewOption {
+    ACTIVE("삭제되지 않은 멤버만 조회") {
+        @Override
+        public List<Member> filterMembers(List<Member> members) {
+            return members.stream()
+                    .filter(member -> !member.getIsDeleted())
+                    .collect(Collectors.toList());
+        }
+    },
+    DELETED("삭제된 멤버만 조회") {
+        @Override
+        public List<Member> filterMembers(List<Member> members) {
+            return members.stream()
+                    .filter(Member::getIsDeleted)
+                    .collect(Collectors.toList());
+        }
+    },
+    ALL("전체 멤버 조회") {
+        @Override
+        public List<Member> filterMembers(List<Member> members) {
+            return members;
+        }
+    };
+
+    private final String description;
+
+    public abstract List<Member> filterMembers(List<Member> members);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       - /verification
       - /verification/confirm
       - /members/find-id
-      - /password/change
+      - /password/reset
       - /refresh
 
   mail:


### PR DESCRIPTION
## 요약

회사(Company) 도메인의 생성, 조회, 수정, 삭제 관련 오류를 수정하고 기능을 개선했습니다.

**주요 변경 사항:**

1.  **수정 오류 해결**:
    *   회사 정보 수정 시, 요청 DTO(`CompanyUpdateRequest`)의 특정 필드가 `null`일 경우 업데이트 과정에서 오류가 발생하던 문제를 해결했습니다. 응답 DTO(`CompanyResponse`, `MemberResponse`)에 `@JsonInclude(JsonInclude.Include.NON_NULL)`을 적용하여 `null` 값 필드는 JSON 응답에서 제외되도록 처리하고, 관련 로직에서 NPE 발생 가능성을 줄였습니다.
2.  **DTO 필드 및 유효성 조정**:
    *   `MemberResponse`에 `email`, `CompanyName`, `isDeleted` 필드 추가.
    *   `CompanyUpdateRequest`의 일부 필드 제약 조건(길이, 패턴)을 현실적인 데이터에 맞게 수정.
3.  **회사 조회 옵션 추가**:
    *   `CompanyViewOption` (활성/전체/삭제된 회사)을 도입하여, 조건에 따라 회사 목록을 조회할 수 있도록 기능을 확장했습니다. (`CompanyController`, `Facade`, `Service`, `Provider`, `Repository` 전반에 반영)
4.  **응답 데이터 명확화**:
    *   `CompanyResponse`에 `isDeleted` 필드를 추가하여 삭제 여부를 명시적으로 제공.

## 연관 이슈

*   Close #318


## Pull Request 체크리스트

### TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?