### PR TITLE
[Fix] 개발사 및 어드민이 승인요청 생성/수정/삭제 되지않는 버그 해결

### DIFF
--- a/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
@@ -33,7 +33,7 @@ public class RequestFacade {
     public RequestCreateResponse createRequest(Long memberId, RequestCreateRequest requestCreateRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Stage stage = stageService.getStageOrThrow(requestCreateRequest.getStageId());
-        projectValidator.validateProjectAuthority(member, requestCreateRequest.getProjectId());
+        projectValidator.validateProjectDevAuthority(member, requestCreateRequest.getProjectId());
 
         return requestService.createRequest(member, stage, requestCreateRequest);
     }
@@ -44,7 +44,7 @@ public class RequestFacade {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request parentRequest = requestService.getRequestOrThrow(requestId);
         Stage stage = stageService.getStageOrThrow(parentRequest.getStage().getId());
-        projectValidator.validateProjectAuthority(member, requestId);
+        projectValidator.validateProjectDevAuthority(member, requestId);
         requestValidator.validateRequestStatus(parentRequest);
 
         return requestService.createReRequest(requestId, member, stage, reRequestCreateRequest);

--- a/src/main/java/com/soda/project/application/stage/request/RequestValidator.java
+++ b/src/main/java/com/soda/project/application/stage/request/RequestValidator.java
@@ -1,9 +1,10 @@
 package com.soda.project.application.stage.request;
 
 import com.soda.global.response.GeneralException;
+import com.soda.member.domain.member.MemberRole;
 import com.soda.project.domain.stage.request.Request;
-import com.soda.project.domain.stage.request.RequestStatus;
 import com.soda.project.domain.stage.request.RequestErrorCode;
+import com.soda.project.domain.stage.request.RequestStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ public class RequestValidator {
 
     public void validaRequestWriter(Long memberId, Request request) {
         boolean isRequestWriter = request.getMember().getId().equals(memberId);
-        if (!isRequestWriter) { throw new GeneralException(RequestErrorCode.USER_NOT_WRITE_REQUEST); }
+        boolean isAdmin = request.getMember().getRole() == MemberRole.ADMIN;
+        if (!isRequestWriter && !isAdmin) { throw new GeneralException(RequestErrorCode.USER_NOT_WRITE_REQUEST); }
     }
 }

--- a/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/response/ResponseFacade.java
@@ -36,7 +36,7 @@ public class ResponseFacade {
                                                  RequestApproveRequest requestApproveRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request request = requestService.getRequestOrThrow(requestId);
-        projectValidator.validateProjectAuthority(member, requestApproveRequest.getProjectId());
+        projectValidator.validateProjectCliAuthority(member, requestApproveRequest.getProjectId());
         requestApproverValidator.validateApprover(member, request.getApprovers());
 
         return responseService.approveRequest(member, request, requestApproveRequest);
@@ -48,7 +48,7 @@ public class ResponseFacade {
                                                RequestRejectRequest requestRejectRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request request = requestService.getRequestOrThrow(requestId);
-        projectValidator.validateProjectAuthority(member, requestRejectRequest.getProjectId());
+        projectValidator.validateProjectCliAuthority(member, requestRejectRequest.getProjectId());
         requestApproverValidator.validateApprover(member, request.getApprovers());
 
         return responseService.rejectRequest(member, request, requestRejectRequest);

--- a/src/main/java/com/soda/project/application/validator/ProjectValidator.java
+++ b/src/main/java/com/soda/project/application/validator/ProjectValidator.java
@@ -33,13 +33,27 @@ public class ProjectValidator {
     private final MemberService memberService;
     private final MemberProjectService memberProjectService;
 
-    public void validateProjectAuthority(Member member, Long projectId) {
+    public void validateProjectCliAuthority(Member member, Long projectId) {
         if (!isCliInCurrentProject(projectId, member) && !isAdmin(member.getRole())) {
             throw new GeneralException(CommonErrorCode.USER_NOT_IN_PROJECT_CLI);
         }
     }
 
-    private static boolean isCliInCurrentProject(Long projectId, Member member) {
+    public void validateProjectDevAuthority(Member member, Long projectId) {
+        if (!isDevInCurrentProject(projectId, member) && !isAdmin(member.getRole())) {
+            throw new GeneralException(CommonErrorCode.USER_NOT_IN_PROJECT_DEV);
+        }
+    }
+
+    private boolean isDevInCurrentProject(Long projectId, Member member) {
+        return member.getMemberProjects().stream()
+                .anyMatch(mp ->
+                        mp.getProject().getId().equals(projectId) &&
+                                (mp.getRole() == MemberProjectRole.DEV_MANAGER || mp.getRole() == MemberProjectRole.DEV_PARTICIPANT)
+                );
+    }
+
+    private boolean isCliInCurrentProject(Long projectId, Member member) {
         return member.getMemberProjects().stream()
                 .anyMatch(mp ->
                         mp.getProject().getId().equals(projectId) &&


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 개발사 및 어드민이 승인요청 생성/수정/삭제 되지않는 버그 해결

# 연관 이슈
#324 

# 확인해야할 사항
- 리팩토링 중 승인요청 생성의 권한처리를 고객사쪽으로 잘못 매칭하여 버그 발생하였음. 개발사 및 어드민이 승인요청 생성/수정 가능하게끔 권한처리 로직 추가하였음