### PR TITLE
[Fix] 파일 메타정보 DB에 저장 할 때 uploads/{uuid}_는 저장되지 않게 수정

### DIFF
--- a/src/main/java/com/soda/project/domain/stage/common/file/FileFactory.java
+++ b/src/main/java/com/soda/project/domain/stage/common/file/FileFactory.java
@@ -26,7 +26,7 @@ public class FileFactory {
 
     public List<FileBase> makeFileEntities(FileStrategy<Object, FileBase> strategy, Object domain, List<ConfirmedFile> confirmedFiles) {
         return confirmedFiles.stream()
-                .map(file -> strategy.toEntity(file.getFileName(), file.getUrl(), domain))
+                .map(file -> strategy.toEntity(file.getFileName().substring(file.getFileName().lastIndexOf("_") + 1), file.getUrl(), domain))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 파일 메타정보 DB에 저장 할 때 uploads/{uuid}_는 저장되지 않게 수정

# 연관 이슈
#330 
