### PR TITLE
[Bug] Spring MVC 비동기 타임아웃 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+  mvc:
+    async:
+      request-timeout: -1
+
   datasource:
     url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DB}
     username: ${MYSQL_USER}


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
SSE(Server-Sent Events) 연결 시, SseEmitter에 설정된 타임아웃(1시간)보다 Spring MVC의 기본 비동기 요청 타임아웃(약 30초)이 먼저 발생하여 SSE 연결이 조기에 종료되는 문제를 해결합니다.
application.yml에 spring.mvc.async.request-timeout=-1 설정을 추가하여 
Spring MVC의 비동기 타임아웃을 비활성화함으로써, SseEmitter가 자체 타임아웃 설정에 따라 동작하도록 수정했습니다.

# 연관 이슈
#335

# Pull Request 체크리스트

## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
