### PR TITLE
[Feature] 로드밸런서 헬스체크용 액츄에이터 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,8 @@ dependencies {
 	// logstash
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
+	// actuator health check
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
       - /members/find-id
       - /password/reset
       - /refresh
+      - /actuator/health
 
   mail:
     host: smtp.gmail.com
@@ -94,3 +95,12 @@ cloud:
       bucket: ${AWS_S3_BUCKET}
     cloudfront:
       domain: ${AWS_CLOUDFRONT_DOMAIN}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION

# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- 로드밸런서 헬스체크용 액츄에이터 추가
  - 부하테스트를 위해 테스트 서버를 띄우고 있는데 scale-out을 염두에 두고 로드밸런서를 달고 있습니다. 이 때 헬스체크가 필요해 헬스체크 API를 자동생성해주는 액츄애이터를 의존성에 추가하고 관련 설정을 추가하였습니다.
 
# 연관 이슈
#341 