### PR TITLE
[Perform] 최근 질문 목록 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/soda/project/domain/stage/article/Article.java
+++ b/src/main/java/com/soda/project/domain/stage/article/Article.java
@@ -20,6 +20,9 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@Table(name = "article", indexes = {
+    @Index(name = "idx_article_member_deleted_created", columnList = "member_id, is_deleted, created_at")
+})
 public class Article extends BaseEntity {
 
     private String title;

--- a/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
@@ -1,30 +1,27 @@
 package com.soda.project.infrastructure.stage.article;
 
+import static com.soda.member.domain.company.QCompany.company;
+import static com.soda.member.domain.member.QMember.member;
+import static com.soda.project.domain.QProject.project;
+import static com.soda.project.domain.stage.QStage.stage;
+import static com.soda.project.domain.stage.article.QArticle.article;
+
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.soda.project.interfaces.stage.article.dto.ArticleSearchCondition;
 import com.soda.project.domain.stage.article.Article;
 import com.soda.project.domain.stage.article.enums.ArticleStatus;
 import com.soda.project.domain.stage.article.enums.PriorityType;
+import com.soda.project.interfaces.stage.article.dto.ArticleSearchCondition;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
-import java.util.Optional;
-
-
-import static com.soda.member.domain.member.QMember.member;
-import static com.soda.member.domain.company.QCompany.company;
-import static com.soda.project.domain.QProject.project;
-import static com.soda.project.domain.stage.QStage.stage;
-import static com.soda.project.domain.stage.article.QArticle.article;
-
 
 @Repository
 @RequiredArgsConstructor
@@ -34,51 +31,58 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
 
     @Override
     public Page<Tuple> findMyArticlesData(Long authorId, Long projectId, Pageable pageable) {
+        List<Tuple> content = executeContentQuery(authorId, projectId, pageable);
+        Long totalCount = executeCountQuery(authorId, projectId);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount);
+    }
 
-        List<Tuple> content = queryFactory
-                .select( // DTO 필드 순서에 맞춰 데이터 선택
-                        article.id,        // articleId
-                        article.title,     // title
-                        project.id,        // projectId (stage를 통해 조인)
-                        project.title,     // projectName (stage를 통해 조인)
-                        stage.id,          // stageId
-                        stage.name,   // stageName
-                        article.createdAt  // createdAt
-                )
-                .from(article)
-                // Article -> Stage 조인
-                .join(article.stage, stage)
-                // Stage -> Project 조인 (Stage 엔티티에 'project' 필드가 있다고 가정)
-                .join(stage.project, project)
-                // Article -> Member 조인 (where 절에서만 사용하므로 명시적 조인 불필요 가능하나, 가독성을 위해 포함)
-                // .join(article.member, member) // member Q 클래스 정의 필요
-                .where(
-                        // article.member 필드를 통해 바로 작성자 ID 비교
-                        article.member.id.eq(authorId),
-                        article.isDeleted.isFalse(),
-                        // projectIdEq 헬퍼 메서드는 project 별칭을 사용
-                        projectIdEq(projectId)
-                )
-                .orderBy(article.createdAt.desc()) // 최신순 정렬
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+    // Content Query 로직 분리
+    private List<Tuple> executeContentQuery(Long authorId, Long projectId, Pageable pageable) {
+        return queryFactory
+            .select(
+                article.id,
+                article.title,
+                project.id,
+                project.title,
+                stage.id,
+                stage.name,
+                article.createdAt
+            )
+            .from(article)
+            .join(article.stage, stage)
+            .join(stage.project, project)
+            .where(
+                article.member.id.eq(authorId),
+                article.isDeleted.isFalse(),
+                projectIdEq(projectId) // projectId가 null이면 이 조건은 무시
+            )
+            .orderBy(article.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+    }
 
-        // Count 쿼리
+    // Count Query 로직 분리
+    private Long executeCountQuery(Long authorId, Long projectId) {
         JPAQuery<Long> countQuery = queryFactory
-                .select(article.count())
-                .from(article)
-                // where 조건에서 project.id를 사용하므로 조인이 필요함
-                .join(article.stage, stage)
-                .join(stage.project, project)
-                // .join(article.member, member) // where 조건에서만 사용 시 count 쿼리 조인 불필요 가능
-                .where(
-                        article.member.id.eq(authorId),
-                        article.isDeleted.isFalse(),
-                        projectIdEq(projectId)
-                );
+            .select(article.count())
+            .from(article);
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        // projectId가 유효할 때만 stage, project 조인하고, where 조건에 추가
+        if (projectId != null && projectId > 0) {
+            countQuery.join(article.stage, stage)
+                .join(stage.project, project)
+                .where(project.id.eq(projectId));
+        }
+
+        // 공통 where 조건 추가
+        countQuery.where(
+            article.member.id.eq(authorId),
+            article.isDeleted.isFalse()
+        );
+
+        Long total = countQuery.fetchOne();
+        return (total == null) ? 0L : total;
     }
 
     @Override


### PR DESCRIPTION
# 요약
최근 질문 목록 조회 API 성능 개선


# 연관 이슈
#345 


# 확인 사항
## 1. `Article`에 복합 인덱스 추가
### 복합 인덱스 사용 이유
- index ⇒ 데이터 조회의 성능 향상을 위해 사용
- 상위 인덱스 값에 대한 하위 인덱스 값을 같이 저장하고 있기 때문에 상위 인덱스로 한 번 필터링된 데이터에서 하위 인덱스의 조건에 맞는 데이터를 찾아낸다.
### 복합 인덱스 설정 후
- MySQL EXPLAIN 실행 시 `Using filesort` 에서 `Backward index scan;`로 변경
- `Using filesort`
   - `ORDER BY a1_0.created_at DESC` 절을 처리하기 위해 인덱스를 사용하지 못하고, 별도의 정렬 작업(filesort)을 수행했음을 의미
   - 데이터가 많을 경우 심각한 성능 저하를 유발 
- `Backward index scan;`
   - ORDER BY created_at DESC를 처리하기 위해 created_at 컬럼에 대해 **인덱스를 역방향으로 스캔**했음을 의미
   - 별도의 정렬 작업(`filesort`) 필요 없어짐

<br/>
<br/>

## 2. `ArticleRepositoryImpl`의 `findMyArticlesData` 메서드 수정
### 메서드 수정 이유
- Count 쿼리 최적화를 위해서
    - 데이터 수를 세기 때문에 데이터가 많아질수록 느려질 수 있음
- `projectId` 유무에 따라 count 쿼리 실행 계획이 다르기 때문
### 수정 내용
- content, count 쿼리를 각각 private method 로 분리
-  `executeCountQuery` 메서드 조인 동적화 코드 적용
    - `projectId`  유무에 따른 조인 동적화 적용

<br/>
<br/>

## 3. 성능 개선 전 vs 후 비교
<img width="543" alt="image" src="https://github.com/user-attachments/assets/788c7384-012d-4067-9f9d-c04f0bfcc5b5" />

1. **API 응답 시간 단축**
    - **416ms에서 45ms로 약 9.2배 빨라짐**
2. **DB 쿼리 성능 개선**:
    - Content 쿼리는 idx_article_member_deleted_created 인덱스와 Backward index scan을 통해 `using filesort` 해결
    - Count 쿼리는 projectId가 null일 때 불필요한 조인을 제거하고, idx_article_member_deleted_created를 커버링 인덱스로 활용


<br/>

### 추가 설명
- 복합 인덱스 사용 이유, 성능 개선 과정 등은 [서연 API 성능 개선](https://quilled-authority-705.notion.site/API-209b5a5bac5380c6a9acf5de46788d24)에서 더 자세히 기록해두었습니다.