### PR TITLE
[Performance] 최근 승인요청 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/soda/project/domain/stage/request/Request.java
+++ b/src/main/java/com/soda/project/domain/stage/request/Request.java
@@ -5,17 +5,18 @@ import com.soda.common.TrackUpdate;
 import com.soda.member.domain.member.Member;
 import com.soda.project.domain.stage.Stage;
 import com.soda.project.domain.stage.request.approver.ApproverDesignation;
-import com.soda.project.interfaces.stage.request.dto.ReRequestCreateRequest;
-import com.soda.project.interfaces.stage.request.dto.RequestCreateRequest;
 import com.soda.project.domain.stage.request.file.RequestFile;
 import com.soda.project.domain.stage.request.link.RequestLink;
 import com.soda.project.domain.stage.request.response.Response;
 import com.soda.project.domain.stage.request.response.ResponseStatus;
+import com.soda.project.interfaces.stage.request.dto.ReRequestCreateRequest;
+import com.soda.project.interfaces.stage.request.dto.RequestCreateRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,17 +49,21 @@ public class Request extends BaseEntity {
 
     @TrackUpdate
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
     private List<RequestFile> files;
 
     @TrackUpdate
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
     private List<RequestLink> links;
 
     @TrackUpdate
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
     private List<ApproverDesignation> approvers;
 
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
     private List<Response> responses;
 
     @Builder

--- a/src/main/java/com/soda/project/domain/stage/request/Request.java
+++ b/src/main/java/com/soda/project/domain/stage/request/Request.java
@@ -24,6 +24,9 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "request", indexes = {
+        @Index(name = "idx_request_member_stage", columnList = "member_id, stage_id")
+})
 public class Request extends BaseEntity {
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/soda/project/domain/stage/request/RequestProvider.java
+++ b/src/main/java/com/soda/project/domain/stage/request/RequestProvider.java
@@ -2,6 +2,7 @@ package com.soda.project.domain.stage.request;
 
 import com.soda.project.interfaces.stage.request.dto.GetMemberRequestCondition;
 import com.soda.project.interfaces.stage.request.dto.GetRequestCondition;
+import com.soda.project.interfaces.stage.request.dto.RequestDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,7 +14,7 @@ public interface RequestProvider {
 
     Page<Request> searchByCondition(Long projectId, GetRequestCondition condition, Pageable pageable);
 
-    Page<Request> searchByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable);
+    Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable);
 
     List<Request> findAllByStage_IdAndIsDeletedFalse(Long stageId);
 

--- a/src/main/java/com/soda/project/domain/stage/request/RequestService.java
+++ b/src/main/java/com/soda/project/domain/stage/request/RequestService.java
@@ -50,8 +50,7 @@ public class RequestService {
     }
 
     public Page<RequestDTO> findMemberRequests(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
-        return requestProvider.searchByMemberCondition(memberId, condition, pageable)
-                .map(RequestDTO::fromEntity);
+        return requestProvider.searchDtosByMemberCondition(memberId, condition, pageable);
     }
 
     public List<RequestDTO> findAllByStageId(Long stageId) {

--- a/src/main/java/com/soda/project/domain/stage/request/approver/ApproverDesignation.java
+++ b/src/main/java/com/soda/project/domain/stage/request/approver/ApproverDesignation.java
@@ -3,10 +3,7 @@ package com.soda.project.domain.stage.request.approver;
 import com.soda.common.BaseEntity;
 import com.soda.member.domain.member.Member;
 import com.soda.project.domain.stage.request.Request;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +15,9 @@ import java.util.stream.Collectors;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "approver_designation", indexes = {
+        @Index(name = "idx_approver_member_request", columnList = "member_id, request_id")
+})
 public class ApproverDesignation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestProviderImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestProviderImpl.java
@@ -4,6 +4,7 @@ import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.RequestProvider;
 import com.soda.project.interfaces.stage.request.dto.GetMemberRequestCondition;
 import com.soda.project.interfaces.stage.request.dto.GetRequestCondition;
+import com.soda.project.interfaces.stage.request.dto.RequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +29,8 @@ public class RequestProviderImpl implements RequestProvider {
     }
 
     @Override
-    public Page<Request> searchByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
-        return requestRepository.searchByMemberCondition(memberId, condition, pageable);
+    public Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
+        return requestRepository.searchDtosByMemberCondition(memberId, condition, pageable);
     }
 
     @Override

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryCustom.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryCustom.java
@@ -1,13 +1,14 @@
 package com.soda.project.infrastructure.stage.request;
 
-import com.soda.project.interfaces.stage.request.dto.GetRequestCondition;
-import com.soda.project.interfaces.stage.request.dto.GetMemberRequestCondition;
 import com.soda.project.domain.stage.request.Request;
+import com.soda.project.interfaces.stage.request.dto.GetMemberRequestCondition;
+import com.soda.project.interfaces.stage.request.dto.GetRequestCondition;
+import com.soda.project.interfaces.stage.request.dto.RequestDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RequestRepositoryCustom {
     Page<Request> searchByCondition(Long projectId, GetRequestCondition condition, Pageable pageable);
 
-    Page<Request> searchByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable);
+    Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -90,101 +90,19 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
 
     @Override
     public Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
-        QRequest request = QRequest.request;
-        QStage stage = QStage.stage;
-        QProject project = QProject.project;
-        QApproverDesignation approver = QApproverDesignation.approverDesignation;
-        QMember member = QMember.member;
+        BooleanBuilder baseCondition = buildCommonCondition(condition);
 
-        BooleanBuilder commonCondition = buildCommonCondition(condition);
+        List<Long> requesterIds = findRequestIdsByRequester(memberId, baseCondition);
+        List<Long> approverIds = findRequestIdsByApprover(memberId, baseCondition);
 
-        List<Long> requesterIds = queryFactory
-                .select(request.id)
-                .from(request)
-                .join(request.stage, stage)
-                .join(stage.project, project)
-                .where(new BooleanBuilder(commonCondition).and(request.member.id.eq(memberId)))
-                .fetch();
+        List<Long> sortedMergedIds = mergeAndSortIds(requesterIds, approverIds);
+        List<Long> pagedIds = paginate(sortedMergedIds, pageable);
 
-        List<Long> approverIds = queryFactory
-                .select(request.id)
-                .from(request)
-                .join(request.stage, stage)
-                .join(stage.project, project)
-                .join(request.approvers, approver)
-                .where(new BooleanBuilder(commonCondition).and(approver.member.id.eq(memberId)))
-                .fetch();
+        List<RequestDTO> unorderedContent = fetchRequestsByIds(pagedIds);
+        List<RequestDTO> orderedContent = restoreOrder(unorderedContent, pagedIds);
 
-        List<Long> mergedIds = mergeAndSortIds(requesterIds, approverIds);
-        List<Long> pagedIds = getPagedIds(mergedIds, pageable);
-
-        List<RequestDTO> content = pagedIds.isEmpty() ? Collections.emptyList() :
-                queryFactory
-                        .select(new QRequestDTO(
-                                request.id,
-                                project.id,
-                                stage.id,
-                                request.member.id,
-                                request.member.name,
-                                request.parentId,
-                                request.title,
-                                request.content,
-                                request.status,
-                                request.createdAt,
-                                request.updatedAt
-                        ))
-                        .from(request)
-                        .join(request.member, member)
-                        .join(request.stage, stage)
-                        .join(stage.project, project)
-                        .where(request.id.in(pagedIds))
-                        .orderBy(request.createdAt.desc())
-                        .fetch();
-
-        return new PageImpl<>(content, pageable, mergedIds.size());
+        return new PageImpl<>(orderedContent, pageable, sortedMergedIds.size());
     }
-
-    private BooleanBuilder buildCommonCondition(GetMemberRequestCondition condition) {
-        QRequest request = QRequest.request;
-        QProject project = QProject.project;
-
-        BooleanBuilder builder = new BooleanBuilder();
-        if (condition.getProjectId() != null) {
-            builder.and(project.id.eq(condition.getProjectId()));
-        }
-        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
-            builder.and(request.title.containsIgnoreCase(condition.getKeyword()));
-        }
-        builder.and(project.isDeleted.eq(false));
-        return builder;
-    }
-
-    private List<Long> mergeAndSortIds(List<Long> list1, List<Long> list2) {
-        return Stream.concat(list1.stream(), list2.stream())
-                .distinct()
-                .sorted(Comparator.reverseOrder()) // 최신순
-                .toList();
-    }
-
-    private List<Long> getPagedIds(List<Long> ids, Pageable pageable) {
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), ids.size());
-        return (start >= ids.size()) ? Collections.emptyList() : ids.subList(start, end);
-    }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort, QRequest request) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
@@ -212,5 +130,106 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
 
         return orderSpecifiers;
     }
+
+    private BooleanBuilder buildCommonCondition(GetMemberRequestCondition condition) {
+        QRequest request = QRequest.request;
+        QProject project = QProject.project;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        if (condition.getProjectId() != null) {
+            builder.and(project.id.eq(condition.getProjectId()));
+        }
+        if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
+            builder.and(request.title.containsIgnoreCase(condition.getKeyword()));
+        }
+        builder.and(project.isDeleted.eq(false));
+
+        return builder;
+    }
+
+    private List<Long> findRequestIdsByRequester(Long memberId, BooleanBuilder condition) {
+        QRequest request = QRequest.request;
+        QStage stage = QStage.stage;
+        QProject project = QProject.project;
+
+        return queryFactory
+                .select(request.id)
+                .from(request)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .where(new BooleanBuilder(condition).and(request.member.id.eq(memberId)))
+                .fetch();
+    }
+
+    private List<Long> findRequestIdsByApprover(Long memberId, BooleanBuilder condition) {
+        QRequest request = QRequest.request;
+        QStage stage = QStage.stage;
+        QProject project = QProject.project;
+        QApproverDesignation approver = QApproverDesignation.approverDesignation;
+
+        return queryFactory
+                .select(request.id)
+                .from(request)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .join(request.approvers, approver)
+                .where(new BooleanBuilder(condition).and(approver.member.id.eq(memberId)))
+                .fetch();
+    }
+
+    private List<Long> mergeAndSortIds(List<Long> list1, List<Long> list2) {
+        return Stream.concat(list1.stream(), list2.stream())
+                .distinct()
+                .sorted(Comparator.reverseOrder()) // 최신순
+                .toList();
+    }
+
+    private List<Long> paginate(List<Long> ids, Pageable pageable) {
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), ids.size());
+        return (start >= ids.size()) ? Collections.emptyList() : ids.subList(start, end);
+    }
+
+    private List<RequestDTO> fetchRequestsByIds(List<Long> ids) {
+        if (ids.isEmpty()) return Collections.emptyList();
+
+        QRequest request = QRequest.request;
+        QStage stage = QStage.stage;
+        QProject project = QProject.project;
+        QMember member = QMember.member;
+
+        return queryFactory
+                .select(new QRequestDTO(
+                        request.id,
+                        project.id,
+                        stage.id,
+                        request.member.id,
+                        request.member.name,
+                        request.parentId,
+                        request.title,
+                        request.content,
+                        request.status,
+                        request.createdAt,
+                        request.updatedAt
+                ))
+                .from(request)
+                .join(request.member, member)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .where(request.id.in(ids))
+                .fetch();
+    }
+
+    private List<RequestDTO> restoreOrder(List<RequestDTO> unordered, List<Long> orderedIds) {
+        Map<Long, Integer> idOrderMap = new HashMap<>();
+        for (int i = 0; i < orderedIds.size(); i++) {
+            idOrderMap.put(orderedIds.get(i), i);
+        }
+
+        return unordered.stream()
+                .sorted(Comparator.comparingInt(dto -> idOrderMap.get(dto.getRequestId())))
+                .toList();
+    }
+
 
 }

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -98,7 +98,6 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
 
         BooleanBuilder commonCondition = buildCommonCondition(condition);
 
-        // 요청자 기준 ID
         List<Long> requesterIds = queryFactory
                 .select(request.id)
                 .from(request)
@@ -107,7 +106,6 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
                 .where(new BooleanBuilder(commonCondition).and(request.member.id.eq(memberId)))
                 .fetch();
 
-        // 결재자 기준 ID
         List<Long> approverIds = queryFactory
                 .select(request.id)
                 .from(request)
@@ -117,7 +115,6 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
                 .where(new BooleanBuilder(commonCondition).and(approver.member.id.eq(memberId)))
                 .fetch();
 
-        // 병합, 중복제거, 최신순 정렬
         List<Long> mergedIds = mergeAndSortIds(requesterIds, approverIds);
         List<Long> pagedIds = getPagedIds(mergedIds, pageable);
 

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -2,9 +2,7 @@ package com.soda.project.infrastructure.stage.request;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soda.member.domain.member.QMember;
 import com.soda.project.domain.QProject;
@@ -24,11 +22,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.soda.member.domain.member.QMember.member;
 
@@ -95,69 +91,102 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
     @Override
     public Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
         QRequest request = QRequest.request;
-        QMember member = QMember.member;
         QStage stage = QStage.stage;
         QProject project = QProject.project;
         QApproverDesignation approver = QApproverDesignation.approverDesignation;
+        QMember member = QMember.member;
 
-        BooleanBuilder baseCondition = new BooleanBuilder();
+        BooleanBuilder commonCondition = buildCommonCondition(condition);
 
+        // 요청자 기준 ID
+        List<Long> requesterIds = queryFactory
+                .select(request.id)
+                .from(request)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .where(new BooleanBuilder(commonCondition).and(request.member.id.eq(memberId)))
+                .fetch();
+
+        // 결재자 기준 ID
+        List<Long> approverIds = queryFactory
+                .select(request.id)
+                .from(request)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .join(request.approvers, approver)
+                .where(new BooleanBuilder(commonCondition).and(approver.member.id.eq(memberId)))
+                .fetch();
+
+        // 병합, 중복제거, 최신순 정렬
+        List<Long> mergedIds = mergeAndSortIds(requesterIds, approverIds);
+        List<Long> pagedIds = getPagedIds(mergedIds, pageable);
+
+        List<RequestDTO> content = pagedIds.isEmpty() ? Collections.emptyList() :
+                queryFactory
+                        .select(new QRequestDTO(
+                                request.id,
+                                project.id,
+                                stage.id,
+                                request.member.id,
+                                request.member.name,
+                                request.parentId,
+                                request.title,
+                                request.content,
+                                request.status,
+                                request.createdAt,
+                                request.updatedAt
+                        ))
+                        .from(request)
+                        .join(request.member, member)
+                        .join(request.stage, stage)
+                        .join(stage.project, project)
+                        .where(request.id.in(pagedIds))
+                        .orderBy(request.createdAt.desc())
+                        .fetch();
+
+        return new PageImpl<>(content, pageable, mergedIds.size());
+    }
+
+    private BooleanBuilder buildCommonCondition(GetMemberRequestCondition condition) {
+        QRequest request = QRequest.request;
+        QProject project = QProject.project;
+
+        BooleanBuilder builder = new BooleanBuilder();
         if (condition.getProjectId() != null) {
-            baseCondition.and(project.id.eq(condition.getProjectId()));
+            builder.and(project.id.eq(condition.getProjectId()));
         }
         if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
-            baseCondition.and(request.title.containsIgnoreCase(condition.getKeyword()));
+            builder.and(request.title.containsIgnoreCase(condition.getKeyword()));
         }
-        baseCondition.and(project.isDeleted.eq(false));
-
-        BooleanExpression requesterCondition = request.member.id.eq(memberId);
-
-        JPQLQuery<RequestDTO> query = queryFactory
-                .select(new QRequestDTO(
-                        request.id,
-                        project.id,
-                        stage.id,
-                        member.id,
-                        member.name,
-                        request.parentId,
-                        request.title,
-                        request.content,
-                        request.status,
-                        request.createdAt,
-                        request.updatedAt
-                ))
-                .from(request)
-                .join(request.member, member)
-                .join(request.stage, stage)
-                .join(stage.project, project)
-                .leftJoin(request.approvers, approver)
-                .where(baseCondition.and(
-                        requesterCondition.or(approver.member.id.eq(memberId))
-                ))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
-
-        List<OrderSpecifier<?>> orderSpecifiers = getOrderSpecifiers(pageable.getSort(), request);
-        if (!orderSpecifiers.isEmpty()) {
-            query.orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]));
-        } else {
-            query.orderBy(request.createdAt.desc());
-        }
-
-        List<RequestDTO> content = query.fetch();
-
-        long total = queryFactory
-                .selectFrom(request)
-                .leftJoin(request.approvers, approver)
-                .join(request.stage, stage)
-                .join(stage.project, project)
-                .where(baseCondition.and(
-                        requesterCondition.or(approver.member.id.eq(memberId))
-                ))
-                .fetchCount();
-
-        return new PageImpl<>(content, pageable, total);
+        builder.and(project.isDeleted.eq(false));
+        return builder;
     }
+
+    private List<Long> mergeAndSortIds(List<Long> list1, List<Long> list2) {
+        return Stream.concat(list1.stream(), list2.stream())
+                .distinct()
+                .sorted(Comparator.reverseOrder()) // 최신순
+                .toList();
+    }
+
+    private List<Long> getPagedIds(List<Long> ids, Pageable pageable) {
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), ids.size());
+        return (start >= ids.size()) ? Collections.emptyList() : ids.subList(start, end);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
     private List<OrderSpecifier<?>> getOrderSpecifiers(Sort sort, QRequest request) {

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -6,11 +6,16 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.soda.member.domain.member.QMember;
+import com.soda.project.domain.QProject;
+import com.soda.project.domain.stage.QStage;
 import com.soda.project.domain.stage.request.QRequest;
 import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.approver.QApproverDesignation;
 import com.soda.project.interfaces.stage.request.dto.GetMemberRequestCondition;
 import com.soda.project.interfaces.stage.request.dto.GetRequestCondition;
+import com.soda.project.interfaces.stage.request.dto.QRequestDTO;
+import com.soda.project.interfaces.stage.request.dto.RequestDTO;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -88,27 +93,46 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
     }
 
     @Override
-    public Page<Request> searchByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
+    public Page<RequestDTO> searchDtosByMemberCondition(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
         QRequest request = QRequest.request;
-        QApproverDesignation approverDesignation = QApproverDesignation.approverDesignation;
+        QMember member = QMember.member;
+        QStage stage = QStage.stage;
+        QProject project = QProject.project;
+        QApproverDesignation approver = QApproverDesignation.approverDesignation;
 
         BooleanBuilder baseCondition = new BooleanBuilder();
 
         if (condition.getProjectId() != null) {
-            baseCondition.and(request.stage.project.id.eq(condition.getProjectId()));
+            baseCondition.and(project.id.eq(condition.getProjectId()));
         }
         if (condition.getKeyword() != null && !condition.getKeyword().isBlank()) {
             baseCondition.and(request.title.containsIgnoreCase(condition.getKeyword()));
         }
-        baseCondition.and(request.stage.project.isDeleted.eq(false));
+        baseCondition.and(project.isDeleted.eq(false));
 
         BooleanExpression requesterCondition = request.member.id.eq(memberId);
 
-        JPQLQuery<Request> query = queryFactory
-                .selectFrom(request)
-                .leftJoin(request.approvers, approverDesignation).fetchJoin()
+        JPQLQuery<RequestDTO> query = queryFactory
+                .select(new QRequestDTO(
+                        request.id,
+                        project.id,
+                        stage.id,
+                        member.id,
+                        member.name,
+                        request.parentId,
+                        request.title,
+                        request.content,
+                        request.status,
+                        request.createdAt,
+                        request.updatedAt
+                ))
+                .from(request)
+                .join(request.member, member)
+                .join(request.stage, stage)
+                .join(stage.project, project)
+                .leftJoin(request.approvers, approver)
                 .where(baseCondition.and(
-                        requesterCondition.or(approverDesignation.member.id.eq(memberId))
+                        requesterCondition.or(approver.member.id.eq(memberId))
                 ))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
@@ -120,13 +144,15 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
             query.orderBy(request.createdAt.desc());
         }
 
-        List<Request> content = query.fetch();
+        List<RequestDTO> content = query.fetch();
 
         long total = queryFactory
                 .selectFrom(request)
-                .leftJoin(request.approvers, approverDesignation)
+                .leftJoin(request.approvers, approver)
+                .join(request.stage, stage)
+                .join(stage.project, project)
                 .where(baseCondition.and(
-                        requesterCondition.or(approverDesignation.member.id.eq(memberId))
+                        requesterCondition.or(approver.member.id.eq(memberId))
                 ))
                 .fetchCount();
 

--- a/src/main/java/com/soda/project/interfaces/stage/request/dto/GetMemberRequestCondition.java
+++ b/src/main/java/com/soda/project/interfaces/stage/request/dto/GetMemberRequestCondition.java
@@ -4,10 +4,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class GetMemberRequestCondition {
     private Long projectId;
     private String keyword;
+    private LocalDateTime cursor;
 }

--- a/src/main/java/com/soda/project/interfaces/stage/request/dto/RequestDTO.java
+++ b/src/main/java/com/soda/project/interfaces/stage/request/dto/RequestDTO.java
@@ -1,9 +1,10 @@
 package com.soda.project.interfaces.stage.request.dto;
 
-import com.soda.project.interfaces.stage.common.file.dto.FileDTO;
-import com.soda.project.interfaces.stage.common.link.dto.LinkDTO;
+import com.querydsl.core.annotations.QueryProjection;
 import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.RequestStatus;
+import com.soda.project.interfaces.stage.common.file.dto.FileDTO;
+import com.soda.project.interfaces.stage.common.link.dto.LinkDTO;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Builder
 @Getter
 public class RequestDTO {
     private Long requestId;
@@ -28,6 +28,44 @@ public class RequestDTO {
     private RequestStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @Builder
+    public RequestDTO(Long requestId, Long projectId, Long stageId, Long memberId, String memberName,
+                      Long parentId, String title, String content, List<LinkDTO> links,
+                      List<FileDTO> files, List<ApproverDTO> approvers, RequestStatus status,
+                      LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.requestId = requestId;
+        this.projectId = projectId;
+        this.stageId = stageId;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.parentId = parentId == null ? -1 : parentId;
+        this.title = title;
+        this.content = content;
+        this.links = links;
+        this.files = files;
+        this.approvers = approvers;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @QueryProjection
+    public RequestDTO(Long requestId, Long projectId, Long stageId, Long memberId, String memberName,
+                      Long parentId, String title, String content, RequestStatus status,
+                      LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.requestId = requestId;
+        this.projectId = projectId;
+        this.stageId = stageId;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.parentId = parentId == null ? -1 : parentId;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 
     // Entity → DTO 변환
     public static RequestDTO fromEntity(Request request) {


### PR DESCRIPTION
# 요약
- 최근 승인요청 조회 API 성능 개선
- 총 3차의 개선과정을 거침(n+1 해결, OR조건 분리, 인덱싱 등 여러 성능개선기법 적용)

# 연관 이슈
#344 

# 개선 전 문제점
![image](https://github.com/user-attachments/assets/a0a2a7cc-ac72-4733-88ff-24b54b8f9e23)
- n+1 문제가 발생하여 응답시간이 30초 가량 소요됨

# 1차 개선(n+1문제 해결; DTO 직접 조회 & Lazy 조회)
- 다대일 관계인 member, stage 등은 DTO로 직접 조회,
- 일대다 관계인 request_files와 request_links는 BatchSize 설정을 하여 Lazy 조회
하여 n+1 문제를 해결하였음. (쿼리수 52개 -> 3개)
![image](https://github.com/user-attachments/assets/95106e30-2f1a-4568-8aa1-cbc5e434c1c0)
그러나 그럼에도 응답시간이 30초 가량 소요됨

# 2차 개선(OR 조건 분리)
- 최근 승인요청 조회 API에서는 내가 요청한 승인요청 or 내가 받은 승인요청을 모두 가져옴.
- 이 OR 조건이 성능 지연의 원인으로 분석하였음.
  - OR조건은 인덱스를 무력화시키기도 하고, LEFT JOIN과 함께 사용하면 카디널리티가 폭발적으로 증가함(기존에 LEFT JOIN을 사용하였었음)
- 따라서 기존에 하나의 쿼리로 "내가 요청한 승인요청", "내가 받은 승인요청"을 모두 가져오는 방식에서 두 승인요청을 각각의 쿼리로 가져오고 자바 힙에서 병합하는 방식으로 구조를 개선함.
- 그 결과, 쿼리수는 3개에서 4개로 늘었지만, 응답시간은 대폭 개선된 것을 확인할 수 있었음
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/53d24ea4-ba93-401c-9057-bf2fe64e0f41" />
28~30sec -> 약 400ms

# 3차 개선(인덱스 생성 및 쿼리 플랜 확인 & DTO조회 후 자바 힙에서 정렬 )
2차 개선 이후 발생하는 쿼리를 확인하여 적절한 인덱스를 추가해주었음.
(WHERE절이 JOIN절보다 먼저 실행됨을 고려하며 복합인덱스의 순서를 설정하였음)
![image](https://github.com/user-attachments/assets/dd016334-b3bf-4d6e-a7c5-e17aea5b0e09)
![image](https://github.com/user-attachments/assets/d8c73a8c-fe52-43fe-a389-82031362830e)
쿼리 플랜을 따서 확인해보니 대부분의 쿼리가 인덱스를 잘 타는 것을 확인할 수 있었음(본PR 최하단 성능개선 노션링크에 첨부해두었음)
![image](https://github.com/user-attachments/assets/660b330e-4e43-4c39-a5da-0e531f4107e1)
그러나 DTO Projection을 하는 쿼리는 JOIN절이 많아서인지 쿼리옵티마이저가 인덱스를 사용하지 않고 filesort를 하는 것을 확인할 수 있었음
이렇게되면 Request가 많아질 경우 굉장히 비효율적일 것이기 때문에, 
어차피 앞에 두 쿼리로 가져온 데이터들을 mergeAndSortIds에서 정렬하기 때문에 이 정렬 순서를 해시맵형태로 저장해두었다가 dto projection 쿼리날릴 때는 정렬하지 않고 데이터 가져온다음에 자바 힙에서 정렬시키는 방식으로 추가 개선하였음.
![image](https://github.com/user-attachments/assets/f9a9a8a5-0339-4ad8-b7e5-8a9fee2d74ef)
따라서 filesort는 발생하지 않음.

# 최종 개선 결과
![image](https://github.com/user-attachments/assets/2367a381-f6d1-45f1-a912-d8ed54e6c31f)
최종적으로 초기 29sec 걸리던 API를 83ms로 단축하였음.

구체적인 성능개선 과정은 https://www.notion.so/API-206b5a5bac5380d38449f66bf61a4fb3 에 상세히 정리해두었습니다!