### PR TITLE
[Performance] 특정 프로젝트의 승인요청 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/soda/project/domain/stage/request/Request.java
+++ b/src/main/java/com/soda/project/domain/stage/request/Request.java
@@ -3,6 +3,7 @@ package com.soda.project.domain.stage.request;
 import com.soda.common.BaseEntity;
 import com.soda.common.TrackUpdate;
 import com.soda.member.domain.member.Member;
+import com.soda.project.domain.Project;
 import com.soda.project.domain.stage.Stage;
 import com.soda.project.domain.stage.request.approver.ApproverDesignation;
 import com.soda.project.domain.stage.request.file.RequestFile;
@@ -41,6 +42,10 @@ public class Request extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stage_id")
     private Stage stage;
 
@@ -70,8 +75,9 @@ public class Request extends BaseEntity {
     private List<Response> responses;
 
     @Builder
-    public Request(Member member, Stage stage, Long parentId, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
+    public Request(Member member, Project project, Stage stage, Long parentId, String title, String content, RequestStatus status, List<RequestFile> files, List<RequestLink> links) {
         this.member = member;
+        this.project = project;
         this.stage = stage;
         this.parentId = parentId;
         this.title = title;
@@ -84,6 +90,7 @@ public class Request extends BaseEntity {
     public static Request createRequest(Member member, Stage stage, RequestCreateRequest requestCreateRequest) {
         return Request.builder()
                 .member(member)
+                .project(stage.getProject())
                 .stage(stage)
                 .title(requestCreateRequest.getTitle())
                 .content(requestCreateRequest.getContent())
@@ -94,6 +101,7 @@ public class Request extends BaseEntity {
     public static Request createReRequest(Long requestId, Member member, Stage stage, ReRequestCreateRequest reRequestCreateRequest) {
         return Request.builder()
                 .member(member)
+                .project(stage.getProject())
                 .stage(stage)
                 .title(reRequestCreateRequest.getTitle())
                 .content(reRequestCreateRequest.getContent())

--- a/src/main/java/com/soda/project/domain/stage/request/Request.java
+++ b/src/main/java/com/soda/project/domain/stage/request/Request.java
@@ -26,7 +26,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "request", indexes = {
-        @Index(name = "idx_request_member_stage", columnList = "member_id, stage_id")
+        @Index(name = "idx_request_member_stage", columnList = "member_id, stage_id"),
+        @Index(name = "idx_request_project_deleted_created", columnList = "project_id, is_deleted, created_at DESC")
 })
 public class Request extends BaseEntity {
 

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -46,7 +46,7 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
         QRequest request = QRequest.request;
         BooleanBuilder builder = new BooleanBuilder();
 
-        builder.and(request.stage.project.id.eq(projectId));
+        builder.and(request.project.id.eq(projectId));
         if (condition.getStageId() != null) {
             builder.and(request.stage.id.eq(condition.getStageId()));
         }
@@ -64,7 +64,7 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
                 .selectFrom(request)
                 .join(request.member, member).fetchJoin()
                 .join(request.stage, stage).fetchJoin()
-                .join(stage.project, project).fetchJoin()
+                .join(request.project, project).fetchJoin()
                 .where(builder.and(request.isDeleted.eq(false)))
                 .orderBy(request.createdAt.desc())
                 .fetch();

--- a/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/request/RequestRepositoryImpl.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.soda.member.domain.member.QMember.member;
+import static com.soda.project.domain.QProject.project;
+import static com.soda.project.domain.stage.QStage.stage;
 
 
 @Slf4j
@@ -61,6 +63,8 @@ public class RequestRepositoryImpl implements RequestRepositoryCustom {
         List<Request> allRequests = queryFactory
                 .selectFrom(request)
                 .join(request.member, member).fetchJoin()
+                .join(request.stage, stage).fetchJoin()
+                .join(stage.project, project).fetchJoin()
                 .where(builder.and(request.isDeleted.eq(false)))
                 .orderBy(request.createdAt.desc())
                 .fetch();


### PR DESCRIPTION
# 요약
- Request -> Stage n+1 문제 해결
- Request에 Project 연관관계 생성(프로젝트의 승인요청 조회시 projectId로 인덱스 타서 Request 조회 빠르게 하기 위함)
- Request테이블에 (project_id, is_deleted, created_at desc) 복합 인덱스 생성


# 연관 이슈
#344 

# 개선 점 문제점
API를 호출했을 때 Request의 Stage에 n+1문제가 발생함을 확인할 수 있었음.
자세한 사항은 본 PR 최하단 노션 링크 참고

# 개선 사항
- 따라서 Stage를 페치조인해서 가져오는 방식으로 n+1문제를 해결하였음.
- 이에 더해, "프로젝트의 승인요청을 조회하는 API"이기 때문에 ProjectId 인덱스를 기반으로 Request를 조회하면 조회 성능을 끌어올릴 수 있겠다고 판단하여, 
  1. Request에 Project연관관게를 추가하고
  2. Request에 (project_id, is_deleted, created_at desc)의 복합인덱스를 생성함
    - 이는 발생하는 쿼리문을 분석하여 순서를 고려하여 복합인덱스를 구성하였음.
  Request에 굳이 Project를 추가해야하는가 라는 의문이 들 수 있지만, 이 API는 SODA의 핵심 API로서 호출이 굉장히 잦으므로 본 API에 한해서는 확장성보다는 조회 성능이 더 중요하다고 판단하여 Project 연관관계를 추가하였음

# 특이 사항
- 기존 Request테이블에 project_id라는 외래키가 없었는데 새로이 추가해줬으므로 
기존 Request 데이터들의 project_id에는 null이 저장돼있을 것임. 이렇게 되면 승인요청조회API가 깨질 수 있으므로 적절한 project_id를 삽입해주기 위해 아래 쿼리를 따로 실행해주었음
```sql
UPDATE request r
JOIN stage s ON r.stage_id = s.id
SET r.project_id = s.project_id
WHERE r.project_id IS NULL
```

# 결과
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/64bc4061-f3c7-4f16-9cf9-468988f5f6b3" />
기존 약 150~200ms 소요되던 응답시간을 약 70ms로 2배 이상 개선함.

자세한 내용은 
https://www.notion.so/API-206b5a5bac5380d38449f66bf61a4fb3
에 상세히 정리해두었음!!