### PR TITLE
[Perform] 특정 프로젝트의 질문 목록 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/soda/project/domain/member/MemberProject.java
+++ b/src/main/java/com/soda/project/domain/member/MemberProject.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@Table(name = "member_project", indexes = {
+    @Index(name = "idx_member_project_deleted", columnList = "member_id, project_id, is_deleted")
+})
 public class MemberProject extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/soda/project/domain/stage/article/Article.java
+++ b/src/main/java/com/soda/project/domain/stage/article/Article.java
@@ -10,15 +10,20 @@ import com.soda.project.domain.stage.article.vote.Vote;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.ToString;
 import org.hibernate.annotations.BatchSize;
 
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(exclude = {"vote", "commentList", "articleFileList", "articleLinkList", "childArticles", "parentArticle", "member", "stage"})
+@EqualsAndHashCode(callSuper = false)
 @Getter
 @Entity
 @Table(name = "article", indexes = {
@@ -145,19 +150,6 @@ public class Article extends BaseEntity {
         for (ArticleLink link : links) {
             link.updateResponse(this);
             this.articleLinkList.add(link);
-        }
-    }
-
-    public void associateVote(Vote vote) {
-        if (vote == null) {
-            // 만약 기존 vote가 있었다면 연결 해제 (orphanRemoval=true로 인해 DB에서 삭제될 수 있음)
-            if (this.vote != null) {
-                this.vote.disassociateArticle();
-            }
-            this.vote = null;
-        } else {
-            this.vote = vote;
-            vote.associateArticle(this);
         }
     }
 

--- a/src/main/java/com/soda/project/domain/stage/article/Article.java
+++ b/src/main/java/com/soda/project/domain/stage/article/Article.java
@@ -24,6 +24,7 @@ import org.hibernate.annotations.BatchSize;
 @Table(name = "article", indexes = {
     @Index(name = "idx_article_member_deleted_created", columnList = "member_id, is_deleted, created_at")
 })
+@BatchSize(size = 50)
 public class Article extends BaseEntity {
 
     private String title;

--- a/src/main/java/com/soda/project/domain/stage/article/Article.java
+++ b/src/main/java/com/soda/project/domain/stage/article/Article.java
@@ -10,20 +10,16 @@ import com.soda.project.domain.stage.article.vote.Vote;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.ToString;
 import org.hibernate.annotations.BatchSize;
 
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"vote", "commentList", "articleFileList", "articleLinkList", "childArticles", "parentArticle", "member", "stage"})
-@EqualsAndHashCode(callSuper = false)
 @Getter
 @Entity
 @Table(name = "article", indexes = {

--- a/src/main/java/com/soda/project/domain/stage/article/Article.java
+++ b/src/main/java/com/soda/project/domain/stage/article/Article.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.annotations.BatchSize;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -54,7 +55,7 @@ public class Article extends BaseEntity {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private List<ArticleLink> articleLinkList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true, optional = true)
+    @OneToOne(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true, optional = true, fetch = FetchType.LAZY)
     private Vote vote;
 
     // 부모 게시글을 위한 필드 (답글이 부모 게시글을 참조)
@@ -64,6 +65,7 @@ public class Article extends BaseEntity {
 
     // 자식 게시글 리스트 (양방향 관계에서 부모 게시글이 자식 게시글을 가질 수 있게 설정)
     @OneToMany(mappedBy = "parentArticle", cascade = CascadeType.ALL)
+    @BatchSize(size = 50)
     private List<Article> childArticles = new ArrayList<>();
 
     // 부모 게시글이 없으면 일반 게시글, 있으면 답글

--- a/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
@@ -11,9 +11,11 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.soda.project.domain.stage.article.Article;
+import com.soda.project.domain.stage.article.QArticle;
 import com.soda.project.domain.stage.article.enums.ArticleStatus;
 import com.soda.project.domain.stage.article.enums.PriorityType;
 import com.soda.project.interfaces.stage.article.dto.ArticleSearchCondition;
+import com.soda.project.interfaces.stage.article.dto.ArticleSearchCondition.SearchType;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -104,10 +106,10 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
     @Override
     public Page<Article> searchArticles(Long projectId, ArticleSearchCondition request, Pageable pageable) {
         List<Article> content = queryFactory
-                .selectFrom(article)
-                .leftJoin(article.stage, stage).fetchJoin()    // Fetch Join 유지 또는 필요시 제거/변경
-                .leftJoin(article.member, member).fetchJoin()    // Fetch Join 유지 또는 필요시 제거/변경
-                .leftJoin(member.company, company).fetchJoin() // Company 정보도 필요하면 Fetch Join
+                .selectFrom(article) // Article
+                .leftJoin(article.stage, stage).fetchJoin()    // WHERE 조건 때문에 stage 필요
+                .leftJoin(article.member, member).fetchJoin()    // member가 DTO에 필요
+                .leftJoin(article.parentArticle).fetchJoin()
                 .where(
                         stage.project.id.eq(projectId),
                         article.isDeleted.isFalse(),
@@ -125,14 +127,20 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(article.count())
                 .from(article)
-                .join(article.stage, stage) // where 조건에서 stage 사용하므로 필요
-                .join(article.member, member) // where 조건에서 member 사용하면 필요 (searchCondition 확인)
-                .where(
-                        stage.project.id.eq(projectId),
-                        article.isDeleted.isFalse(),
-                        stageIdEq(request.getStageId()),
-                        searchCondition(request.getSearchType(), request.getKeyword())
-                );
+                .join(article.stage, stage);
+
+        if (request.getSearchType() == SearchType.AUTHOR && StringUtils.hasText(request.getKeyword())) {
+            countQuery.join(article.member, member);
+        }
+
+        countQuery.where(
+            stage.project.id.eq(projectId),
+            article.isDeleted.isFalse(),
+            stageIdEq(request.getStageId()),
+            searchCondition(request.getSearchType(), request.getKeyword()),
+            articleStatusEq(request.getStatus()),
+            priorityTypeEq(request.getPriorityType())
+        );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/stage/article/ArticleRepositoryImpl.java
@@ -109,7 +109,6 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                 .selectFrom(article) // Article
                 .leftJoin(article.stage, stage).fetchJoin()    // WHERE 조건 때문에 stage 필요
                 .leftJoin(article.member, member).fetchJoin()    // member가 DTO에 필요
-                .leftJoin(article.parentArticle).fetchJoin()
                 .where(
                         stage.project.id.eq(projectId),
                         article.isDeleted.isFalse(),


### PR DESCRIPTION
# 요약
- `MemberProject` 조회 성능 개선
- `Child Article` 및 `Vote` 조회 N+1 문제 해


# 연관 이슈
#346 
close #346 


# 개선 사항
## 1. N+1 문제 해결
### `@BatchSize` 설정
- `childArticles` 조회 시 N+1 문제가 발생하고 있어서 `childArticles` 컬럼에 `@BatchSize` 설정 추가
- `Article` 클래스 단위에 `@BatchSize` 추가 (추가한 이유는 노션에 자세히 기록해두었습니다)
### Content 쿼리 fetch join 최적화
- DTO에서 필요한 정보만 가져오도록 필요 없는 조인 삭제
### Count 쿼리 수정
- Content 쿼리와 동일한 필터링 조건을 갖도록 수정
- `searchType`이 `AUTHOR`인 경우와 `keyword`로 검색할 경우에만 member가 필요하므로 해당 조건 만족 시에만 member JOIN

<br/>
<br/>

## 2. `Member_Project` 복합 인덱스 설정
- 처음 EXPLAIN 실행 시 `Using where` 발견
   - `member_id` 또는 `project_id` 중 하나만 인덱스로 사용되었을 것으로 추정
- `member_id`, `project_id`, `is_deleted`로 이루어진 복합 인덱스 설정 (순서 판단 내용은 노션에 기록해두었음)
- 설정 이후 `Using index`로 동작하는 걸 확인

<br/>
<br/>

## 성능 개선 전 vs 후 비교 (최종 API 응답 시간 661ms → 129ms)
항목 | 개선 전 (661ms 응답) | 최종 개선 후 (129ms 응답) | 개선 효과
-- | -- | -- | --
Member_Project 조회 | 약 264ms | 약 8ms | 약 256ms 단축 (인덱스 최적화 + DB 캐시)
Content 쿼리 | 약 29ms | 약 13ms | 약 16ms 단축
Count 쿼리 | 약 32ms | 약 7ms | 약 25ms 단축 (인덱스 활용 및 DB 캐시)
ChildArticle 조회 | 약 70-80ms (N+1 또는 비효율적) | 약 25ms (배치 조회) | 약 45-55ms 단축 (`@BatchSize` 효과)
최종 API 응답 시간 | 661ms | 129ms | 약 532ms 단축 (약 80.5% 성능 향상)
주요 문제점 | 다수의 N+1, 비효율적 인덱스 | 모든 주요 N+1 해결, 인덱스 최적화 |  



<br/>

더 자세한 내용은 [특정 프로젝트의 질문 목록 조회 API 성능 개선](https://quilled-authority-705.notion.site/API-20eb5a5bac538003abded20f93ed991c)에 기록하였습니다.