### PR TITLE
[Perform] 참여중인 프로젝트 조회 API 성능 개선

### DIFF
--- a/src/main/java/com/soda/project/application/ProjectFacade.java
+++ b/src/main/java/com/soda/project/application/ProjectFacade.java
@@ -170,9 +170,8 @@ public class ProjectFacade {
         // 1. 권한 검증
         if (!"USER".equals(userRole)) return Page.empty(pageable);
         // 2. 데이터 조회
-        Page<Tuple> tuplePage = projectService.findMyProjectsData(request, userId, pageable);
-        // 3. DTO 변환
-        return projectResponseBuilder.createMyProjectListResponsePage(tuplePage, true);
+        Page<MyProjectListResponse> tuplePage = projectService.findMyProjectsData(request, userId, pageable);
+        return tuplePage;
     }
 
     public ProjectViewResponse getProject(Long userId, String userRole, Long projectId) {

--- a/src/main/java/com/soda/project/domain/ProjectProvider.java
+++ b/src/main/java/com/soda/project/domain/ProjectProvider.java
@@ -1,6 +1,7 @@
 package com.soda.project.domain;
 
 import com.querydsl.core.Tuple;
+import com.soda.project.interfaces.dto.MyProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import org.springframework.data.domain.Page;
@@ -15,7 +16,7 @@ public interface ProjectProvider {
 
     Page<ProjectListResponse> searchProjects(ProjectSearchCondition projectSearchCondition, Pageable pageable);
 
-    Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long userId, Pageable pageable);
+    Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long userId, Pageable pageable);
 
     Page<Tuple> findMyCompanyProjectsData(Long userId, Long companyId, Pageable pageable);
 

--- a/src/main/java/com/soda/project/domain/ProjectService.java
+++ b/src/main/java/com/soda/project/domain/ProjectService.java
@@ -5,6 +5,7 @@ import com.soda.global.response.GeneralException;
 import com.soda.member.domain.member.Member;
 import com.soda.member.domain.company.Company;
 import com.soda.project.domain.company.CompanyProjectRole;
+import com.soda.project.interfaces.dto.MyProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import lombok.RequiredArgsConstructor;
@@ -87,7 +88,7 @@ public class ProjectService {
     /**
      * 특정 사용자가 참여한 프로젝트 목록 조회 메서드
      */
-    public Page<Tuple> findMyProjectsData(ProjectSearchCondition condition, Long userId, Pageable pageable) {
+    public Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition condition, Long userId, Pageable pageable) {
         return projectProvider.findMyProjectsData(condition, userId, pageable);
     }
 

--- a/src/main/java/com/soda/project/infrastructure/ProjectProviderImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/ProjectProviderImpl.java
@@ -3,6 +3,7 @@ package com.soda.project.infrastructure;
 import com.querydsl.core.Tuple;
 import com.soda.project.domain.Project;
 import com.soda.project.domain.ProjectProvider;
+import com.soda.project.interfaces.dto.MyProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,8 @@ public class ProjectProviderImpl implements ProjectProvider {
     }
 
     @Override
-    public Page<Tuple> findMyProjectsData(ProjectSearchCondition request, Long userId, Pageable pageable) {
-        return projectRepository.findMyProjectsData(request, userId,pageable);
+    public Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition request, Long userId, Pageable pageable) {
+        return projectRepository.findMyProjectsData(request, userId, pageable);
     }
 
     @Override

--- a/src/main/java/com/soda/project/infrastructure/ProjectRepositoryCustom.java
+++ b/src/main/java/com/soda/project/infrastructure/ProjectRepositoryCustom.java
@@ -1,13 +1,14 @@
 package com.soda.project.infrastructure;
 
 import com.querydsl.core.Tuple;
+import com.soda.project.interfaces.dto.MyProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProjectRepositoryCustom {
-    Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable);
+    Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable);
 
     Page<Tuple> findMyCompanyProjectsData(Long memberId, Long companyId, Pageable pageable);
 

--- a/src/main/java/com/soda/project/infrastructure/ProjectRepositoryImpl.java
+++ b/src/main/java/com/soda/project/infrastructure/ProjectRepositoryImpl.java
@@ -11,16 +11,23 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.soda.project.domain.QProject;
-import com.soda.project.domain.company.QCompanyProject;
+import com.soda.member.domain.company.QCompany;
+import com.soda.member.domain.member.QMember;
+import com.soda.project.domain.Project;
 import com.soda.project.domain.ProjectStatus;
+import com.soda.project.domain.QProject;
+import com.soda.project.domain.company.CompanyProjectRole;
+import com.soda.project.domain.company.QCompanyProject;
+import com.soda.project.domain.member.MemberProjectRole;
 import com.soda.project.domain.member.QMemberProject;
 import com.soda.project.domain.stage.QStage;
 import com.soda.project.domain.stage.article.QArticle;
 import com.soda.project.domain.stage.request.QRequest;
+import com.soda.project.interfaces.dto.MyProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -30,8 +37,12 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
@@ -41,27 +52,19 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     private static final QProject project = QProject.project;
     private static final QMemberProject memberProject = QMemberProject.memberProject;
     private static final QCompanyProject companyProject = QCompanyProject.companyProject;
+    private static final QMember member = QMember.member;
+    private static final QCompany company = QCompany.company;
 
     @Override
-    public Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable) {
-        List<Tuple> content = queryFactory
-                .select(
-                        project,
-                        companyProject.companyProjectRole,
-                        memberProject.role
-                )
+    public Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable) {
+        List<Long> projectIds = queryFactory
+                .select(project.id)
                 .from(project)
-                // 1. 특정 멤버가 참여하는 프로젝트 필터링
                 .join(project.memberProjects, memberProject)
-                .join(project.companyProjects, companyProject)
-                .on(companyProject.company.id.eq(
-                        memberProject.member.company.id
-                ))
                 .where(
-                        memberProject.member.id.eq(memberId),
                         project.isDeleted.isFalse(),
+                        memberProject.member.id.eq(memberId),
                         memberProject.isDeleted.isFalse(),
-                        companyProject.isDeleted.isFalse(), // 회사 연결도 활성 상태
                         statusEq(projectSearchCondition.getStatus()),
                         titleContains(projectSearchCondition.getKeyword())
                 )
@@ -70,18 +73,58 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        // Count 쿼리도 동일한 조인 및 조건 적용
-        JPAQuery<Long> countQuery = queryFactory
-                .select(project.countDistinct())
+        if (projectIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        project,
+                        companyProject.companyProjectRole,
+                        memberProject.role
+                )
                 .from(project)
                 .join(project.memberProjects, memberProject)
-                .join(project.companyProjects, companyProject)
-                .on(companyProject.company.id.eq(memberProject.member.company.id))
+                .on(memberProject.project.id.in(projectIds)
+                        .and(memberProject.member.id.eq(memberId))
+                        .and(memberProject.isDeleted.isFalse()))
+                .join(memberProject.member, member)
+                .leftJoin(project.companyProjects, companyProject)
+                .on(companyProject.project.eq(project)
+                        .and(companyProject.company.id.eq(member.company.id))
+                        .and(companyProject.isDeleted.isFalse()))
+                .fetch();
+
+        Map<Long, Tuple> tupleMap = tuples.stream()
+                .collect(Collectors.toMap(t -> t.get(project).getId(), Function.identity(), (t1, t2) -> t1));
+
+        List<MyProjectListResponse> content = projectIds.stream()
+                .map(pId -> {
+                    Tuple tuple = tupleMap.get(pId);
+                    if (tuple == null) {
+                        log.warn("Tuple not found for projectId: {} in tupleMap for /projects/my. This might happen if there's data inconsistency.", pId);
+                        return null;
+                    }
+                    Project p = tuple.get(project);
+                    CompanyProjectRole cpr = tuple.get(companyProject.companyProjectRole);
+                    MemberProjectRole mpr = tuple.get(memberProject.role);
+                    if (p == null || mpr == null) {
+                        log.error("Critical: Project or MemberProjectRole is null in tuple for projectId {} and memberId {}.", (p != null ? p.getId() : "null_project"), memberId);
+                        return null;
+                    }
+                    return MyProjectListResponse.from(p, cpr, mpr);
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(project.count())
+                .from(project)
+                .join(project.memberProjects, memberProject)
                 .where(
-                        memberProject.member.id.eq(memberId),
                         project.isDeleted.isFalse(),
+                        memberProject.member.id.eq(memberId),
                         memberProject.isDeleted.isFalse(),
-                        companyProject.isDeleted.isFalse(),
                         statusEq(projectSearchCondition.getStatus()),
                         titleContains(projectSearchCondition.getKeyword())
                 );
@@ -98,11 +141,9 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                         memberProject.role
                 )
                 .from(project)
-                // 회사가 참여한 프로젝트 찾기
                 .join(project.companyProjects, companyProject)
-                // 현재 사용자의 멤버 역할 찾기
                 .leftJoin(project.memberProjects, memberProject)
-                .on(memberProject.member.id.eq(memberId) // 현재 사용자
+                .on(memberProject.member.id.eq(memberId)
                         .and(memberProject.isDeleted.isFalse()))
                 .where(
                         companyProject.company.id.eq(companyId),
@@ -114,7 +155,6 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        // Count 쿼리 (회사 기준으로 count)
         JPAQuery<Long> countQuery = queryFactory
                 .select(project.countDistinct())
                 .from(project)
@@ -130,7 +170,6 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
     @Override
     public Page<ProjectListResponse> searchProjects(ProjectSearchCondition condition, Pageable pageable) {
-        QProject project = QProject.project;
         QStage stage = QStage.stage;
         QRequest requestEntity = QRequest.request;
         QArticle article = QArticle.article;
@@ -221,7 +260,6 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
     }
 
     private BooleanExpression titleContains(String keyword) {
-        // StringUtils.hasText 사용하여 null 또는 빈 문자열 체크
         return StringUtils.hasText(keyword) ? project.title.containsIgnoreCase(keyword) : null;
     }
 }


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
- GET /projects/my API의 성능 저하 문제를 해결했습니다.
- 총 2차의 개선 과정을 거쳤습니다 (커버링 인덱스 전략 도입, 쿼리 구조 최적화, 인덱스 설계)
- 초기 506ms 걸리던 API를 최종 60ms로 단축하여 약 8.4배의 성능 향상을 이뤘습니다.

# 개선 전 문제점
- 내 프로젝트 목록 조회 API의 응답 시간이 평균 506ms로 측정되어 사용자 경험을 저해하는 문제가 있었습니다.
- 원인 분석 결과, 복잡한 JOIN과 다른 테이블 컬럼 기준의 ORDER BY로 인해 발생하는 비효율적인 DB 쿼리가 병목의 핵심이었습니다.

**[개선 전 Repository 코드]**
```
// ProjectRepositoryImpl.java
@Override
public Page<Tuple> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable) {
    List<Tuple> content = queryFactory
            .select(
                    project,
                    companyProject.companyProjectRole,
                    memberProject.role
            )
            .from(project)
            .join(project.memberProjects, memberProject)
            .join(project.companyProjects, companyProject) 
            .on(companyProject.company.id.eq(memberProject.member.company.id))
            .where(
                    memberProject.member.id.eq(memberId),
                    // ...
            )
            .orderBy(project.createdAt.desc()) 
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize())
            .fetch();

    JPAQuery<Long> countQuery = // ...
    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
}
```

![image](https://github.com/user-attachments/assets/0185b7eb-4aa2-44cb-a582-7e2a7ee1ec77)

# 개선 과정 (쿼리 분리 및 실행 계획 분석)
- 쿼리 2단계 분리:
  1. ID 목록 조회: ORDER BY를 적용하여 필요한 project_id 목록만 SELECT 절에 포함해 조회합니다. "커버링 인덱스"를 활용하여 디스크 I/O를 최소화하고 페이징 처리의 부하를 줄였습니다.
  2. 상세 정보 조회: 1단계에서 얻은 id 목록을 IN 절에 사용하여, 정렬 없이 필요한 상세 정보만 조회합니다.
- DTO 변환 로직 이동: 1단계에서 얻은 정렬 순서를 최종 결과까지 유지하기 위해, Repository 단에서 id 목록과 상세 정보를 조합하여 DTO로 변환하도록 로직을 이동시켰습니다.

**[1차 개선 후 Repository 코드]**
```
// ProjectRepositoryImpl.java
@Override
public Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition projectSearchCondition, Long memberId, Pageable pageable) {
    List<Long> projectIds = queryFactory
            .select(project.id) 
            .from(project)
            .join(project.memberProjects, memberProject)
            .where(...)
            .orderBy(project.createdAt.desc())
            .limit(pageable.getPageSize())
            .fetch();

    if (projectIds.isEmpty()) {
        return Page.empty(pageable);
    }

    List<Tuple> tuples = queryFactory
            .select(...)
            .from(project)
            .where(project.id.in(projectIds)) 
            .fetch();

    Map<Long, Tuple> tupleMap = ...;
    List<MyProjectListResponse> content = projectIds.stream()
            .map(pId -> { ... })
            .collect(Collectors.toList());

    JPAQuery<Long> countQuery = // ...
    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
}
```

# 최종 개선 결과

![image](https://github.com/user-attachments/assets/5131b360-ae95-4110-9c6d-f4e50c675205)

-**결과**: 응답 시간이 506ms에서 약 60ms으로 개선되었습니다.

# 연관 이슈
#350 

# Pull Request 체크리스트


## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?