### PR TITLE
[Perform] 일반 유저 대시보드 API 성능 개선을 위한 Redis 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 	// smtp
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/com/soda/global/config/PageDeserializer.java
+++ b/src/main/java/com/soda/global/config/PageDeserializer.java
@@ -1,0 +1,49 @@
+package com.soda.global.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PageDeserializer extends JsonDeserializer<PageImpl<?>> {
+
+    @Override
+    public PageImpl<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        JsonNode node = mapper.readTree(p);
+
+        List<?> content = mapper.convertValue(
+                node.get("content"),
+                mapper.getTypeFactory().constructCollectionType(List.class, Object.class)
+        );
+
+        long total = node.get("totalElements").asLong();
+
+        JsonNode pageableData = node.get("pageable").get(1);
+        int number = pageableData.get("pageNumber").asInt();
+        int size = pageableData.get("pageSize").asInt();
+
+        JsonNode sortNode = node.get("sort");
+        List<Sort.Order> orders = new ArrayList<>();
+        if (sortNode != null && sortNode.isArray()) {
+            for (final JsonNode objNode : sortNode) {
+                if (objNode.has("property") && objNode.has("direction")) {
+                    String property = objNode.get("property").asText();
+                    String direction = objNode.get("direction").asText();
+                    orders.add(new Sort.Order(Sort.Direction.fromString(direction), property));
+                }
+            }
+        }
+
+        PageRequest pageRequest = PageRequest.of(number, size, Sort.by(orders));
+        return new PageImpl<>(content, pageRequest, total);
+    }
+}

--- a/src/main/java/com/soda/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/soda/global/config/RedisCacheConfig.java
@@ -1,0 +1,56 @@
+package com.soda.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean(name = "myCacheManager")
+    @Primary
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper redisObjectMapper = new ObjectMapper();
+
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class).build();
+        redisObjectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        redisObjectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        redisObjectMapper.registerModule(new JavaTimeModule());
+
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Page.class, new PageDeserializer());
+        module.addDeserializer(PageImpl.class, new PageDeserializer());
+        redisObjectMapper.registerModule(module);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper)))
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/soda/project/domain/ProjectService.java
+++ b/src/main/java/com/soda/project/domain/ProjectService.java
@@ -10,6 +10,7 @@ import com.soda.project.interfaces.dto.ProjectListResponse;
 import com.soda.project.interfaces.dto.ProjectSearchCondition;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -88,7 +89,17 @@ public class ProjectService {
     /**
      * 특정 사용자가 참여한 프로젝트 목록 조회 메서드
      */
+    @Cacheable(value = "myProjects",
+            key = "'user:' + #userId + " +
+                    "':status:' + (#condition.status == null ? 'null' : #condition.status.name()) + " +
+                    "':keyword:' + (#condition.keyword == null ? 'null' : #condition.keyword) + " +
+                    "':page:' + #pageable.pageNumber + " +
+                    "':size:' + #pageable.pageSize + " +
+                    "':sort:' + (#pageable.sort.isSorted() ? #pageable.sort.toString() : 'UNSORTED')",
+            cacheManager = "myCacheManager",
+            unless = "#result == null or !#result.hasContent()")
     public Page<MyProjectListResponse> findMyProjectsData(ProjectSearchCondition condition, Long userId, Pageable pageable) {
+        log.info("===> [Cache Miss] DB에서 사용자 {}의 프로젝트 목록을 조회합니다. 조건: {}, 페이지: {}", userId, condition, pageable);
         return projectProvider.findMyProjectsData(condition, userId, pageable);
     }
 

--- a/src/main/java/com/soda/project/interfaces/dto/MyProjectListResponse.java
+++ b/src/main/java/com/soda/project/interfaces/dto/MyProjectListResponse.java
@@ -4,13 +4,17 @@ import com.soda.project.domain.company.CompanyProjectRole;
 import com.soda.project.domain.member.MemberProjectRole;
 import com.soda.project.domain.Project;
 import com.soda.project.domain.ProjectStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MyProjectListResponse {
 
     private Long projectId;

--- a/src/main/java/com/soda/project/interfaces/dto/ProjectSearchCondition.java
+++ b/src/main/java/com/soda/project/interfaces/dto/ProjectSearchCondition.java
@@ -1,6 +1,7 @@
 package com.soda.project.interfaces.dto;
 
 import com.soda.project.domain.ProjectStatus;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,9 +9,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class ProjectSearchCondition {
-
     private ProjectStatus status;
     private String keyword;
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: 6379
+  cache:
+    type: redis
 
   servlet:
     multipart:


### PR DESCRIPTION
# 요약
일반 사용자의 대시보드에 표시되는 '참여중인 프로젝트' 목록 조회 API의 응답 속도를 개선하고 DB 부하를 줄이기 위해 Redis 캐싱을 도입했습니다. 사용자가 반복적으로 자신의 프로젝트 목록을 조회할 때, 첫 조회 이후에는 Redis에 저장된 데이터를 즉시 반환하여 빠른 응답을 제공합니다.

이번 PR은 **캐시 데이터를 생성하고 조회하는 `Cache-Aside` 패턴의 구현**에 중점을 두었으며, 캐시 무효화 로직은 후속 PR에서 다룰 예정입니다.

## 주요 구현 내용
1.  **캐시 읽기 전략 적용 (`Cache-Aside`)**
    - `@Cacheable` 어노테이션을 사용하여 API가 호출될 때 먼저 Redis를 조회하도록 구현했습니다.
    - 데이터가 없으면(Cache Miss) DB에서 조회한 후 그 결과를 Redis에 저장합니다.
    - 데이터가 있으면(Cache Hit) Redis에서 즉시 반환하여 DB 접근을 피합니다.

2.  **Spring Data `Page` 객체 캐싱 문제 해결**
    - Spring Data의 `Page` 인터페이스와 그 구현체인 `PageImpl`은 기본 생성자가 없어 Jackson 라이브러리가 역직렬화할 수 없는 문제가 있습니다.
    - 이를 해결하기 위해 `PageImpl` 객체를 위한 커스텀 역직렬화기(`PageDeserializer`)를 구현하고, `RedisCacheConfig`에 등록하여 문제를 해결했습니다.

3.  **안정적인 캐시 키(Key) 생성 로직 구현**
    - 검색 조건(`ProjectSearchCondition`)과 페이징 정보(`Pageable`)를 포함하여 고유하고 일관된 캐시 키를 생성하도록 SpEL(Spring Expression Language)을 사용했습니다.
    - DTO 필드가 `null`일 경우에도 `NullPointerException`이 발생하지 않도록 안전하게 키를 조립하는 로직을 적용했습니다.

---
# 향후 계획 (후속 PR)
- **캐시 무효화 전략 구현**: 현재는 TTL에만 의존하고 있어 데이터 정합성에 문제가 발생할 수 있습니다. 프로젝트 정보가 생성/수정/삭제될 때 관련된 캐시를 즉시 삭제하는 **명시적 무효화** 로직(`@CacheEvict` 등)을 추가하여 데이터의 최신성을 보장할 계획입니다.

---
# 연관 이슈
- Close #354

---
# Pull Request 체크리스트

## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) pref: 일반 유저 대시보드 프로젝트 정보 레디스에 캐싱 (#354)
    - 나쁜 예시) feat: 캐싱 구현

## 테스트 결과
- **Cache Miss (최초 호출)**
  - `[Cache Miss]` 로그와 함께 DB 조회 쿼리가 정상적으로 실행됨을 확인했습니다.
  - 응답 시간: 약 200~300ms
- **Cache Hit (두 번째 호출)**
  - `[Cache Miss]` 로그와 DB 쿼리 없이 Redis에서 데이터를 가져옴을 확인했습니다.
  - 응답 시간: 약 20~40ms (약 10배 성능 향상)
  - `redis-cli`를 통해 캐시 키와 값이 정상적으로 저장됨을 확인했습니다.

| 상황 | 응답 시간 | DB 쿼리 | 비고 |
| :-- | :--- | :--- | :--- |
| **Cache Miss** | ~280ms | O | 첫 API 호출 시 |
| **Cache Hit** | ~30ms | X | 두 번째 API 호출 시 (성공) |
