### PR TITLE
[Performance] 특정 유저의 최근 승인요청 캐싱 적용

### DIFF
--- a/src/main/java/com/soda/common/CacheEvictionHelper.java
+++ b/src/main/java/com/soda/common/CacheEvictionHelper.java
@@ -1,0 +1,21 @@
+package com.soda.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CacheEvictionHelper {
+
+    private final CacheManager cacheManager;
+
+    public void evictMyRequestPage0Size3(Long memberId) {
+        Cache cache = cacheManager.getCache("myRequests");
+        if (cache != null) {
+            String key = "member:" + memberId + ":page:0:size:3";
+            cache.evictIfPresent(key);
+        }
+    }
+}

--- a/src/main/java/com/soda/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/soda/global/config/RedisCacheConfig.java
@@ -46,7 +46,7 @@ public class RedisCacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper)))
-                .entryTtl(Duration.ofMinutes(10));
+                .entryTtl(Duration.ofHours(24));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(connectionFactory)

--- a/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
@@ -10,6 +10,8 @@ import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.RequestService;
 import com.soda.project.interfaces.stage.request.dto.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,9 @@ public class RequestFacade {
 
     @LoggableEntityAction(action = "CREATE", entityClass = Request.class)
     @Transactional
+    @CacheEvict(value = "myRequests",
+            key = "'member:' + #memberId + ':page:0:size:3'",
+            cacheManager = "myCacheManager")
     public RequestCreateResponse createRequest(Long memberId, RequestCreateRequest requestCreateRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Stage stage = stageService.getStageOrThrow(requestCreateRequest.getStageId());
@@ -40,6 +45,9 @@ public class RequestFacade {
 
     @LoggableEntityAction(action = "CREATE", entityClass = Request.class)
     @Transactional
+    @CacheEvict(value = "myRequests",
+            key = "'member:' + #memberId + ':page:0:size:3'",
+            cacheManager = "myCacheManager")
     public RequestCreateResponse createReRequest(Long memberId, Long requestId, ReRequestCreateRequest reRequestCreateRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request parentRequest = requestService.getRequestOrThrow(requestId);
@@ -52,6 +60,9 @@ public class RequestFacade {
 
     @LoggableEntityAction(action = "UPDATE", entityClass = Request.class)
     @Transactional
+    @CacheEvict(value = "myRequests",
+            key = "'member:' + #memberId + ':page:0:size:3'",
+            cacheManager = "myCacheManager")
     public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest) {
         Request request = requestService.getRequestOrThrow(requestId);
         requestValidator.validaRequestWriter(memberId, request);
@@ -61,6 +72,9 @@ public class RequestFacade {
 
     @LoggableEntityAction(action = "DELETE", entityClass = Request.class)
     @Transactional
+    @CacheEvict(value = "myRequests",
+            key = "'member:' + #memberId + ':page:0:size:3'",
+            cacheManager = "myCacheManager")
     public RequestDeleteResponse deleteRequest(Long memberId, Long requestId) {
         Request request = requestService.getRequestOrThrow(requestId);
         requestValidator.validaRequestWriter(memberId, request);
@@ -72,6 +86,13 @@ public class RequestFacade {
         return requestService.findRequests(projectId, condition, pageable);
     }
 
+    @Cacheable(value = "myRequests",
+            key = "'member:' + #memberId + " +
+                    "':page:' + #pageable.pageNumber + " +
+                    "':size:' + #pageable.pageSize",
+            cacheManager = "myCacheManager",
+            condition = "#pageable.pageNumber == 0 and #pageable.pageSize == 3",
+            unless = "#result == null or !#result.hasContent()")
     public Page<RequestDTO> findMemberRequests(Long memberId, GetMemberRequestCondition condition, Pageable pageable) {
         return requestService.findMemberRequests(memberId, condition, pageable);
     }

--- a/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
+++ b/src/main/java/com/soda/project/application/stage/request/RequestFacade.java
@@ -1,5 +1,6 @@
 package com.soda.project.application.stage.request;
 
+import com.soda.common.CacheEvictionHelper;
 import com.soda.global.log.data.annotation.LoggableEntityAction;
 import com.soda.member.domain.member.Member;
 import com.soda.member.domain.member.MemberService;
@@ -8,9 +9,9 @@ import com.soda.project.domain.stage.Stage;
 import com.soda.project.domain.stage.StageService;
 import com.soda.project.domain.stage.request.Request;
 import com.soda.project.domain.stage.request.RequestService;
+import com.soda.project.domain.stage.request.approver.ApproverDesignation;
 import com.soda.project.interfaces.stage.request.dto.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,56 +31,69 @@ public class RequestFacade {
     private final ProjectValidator projectValidator;
     private final RequestValidator requestValidator;
 
+    private final CacheEvictionHelper cacheEvictionHelper;
+
     @LoggableEntityAction(action = "CREATE", entityClass = Request.class)
     @Transactional
-    @CacheEvict(value = "myRequests",
-            key = "'member:' + #memberId + ':page:0:size:3'",
-            cacheManager = "myCacheManager")
     public RequestCreateResponse createRequest(Long memberId, RequestCreateRequest requestCreateRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Stage stage = stageService.getStageOrThrow(requestCreateRequest.getStageId());
         projectValidator.validateProjectDevAuthority(member, requestCreateRequest.getProjectId());
+        requestCacheEvictForCreate(memberId, requestCreateRequest.getMembers());
 
         return requestService.createRequest(member, stage, requestCreateRequest);
     }
 
     @LoggableEntityAction(action = "CREATE", entityClass = Request.class)
     @Transactional
-    @CacheEvict(value = "myRequests",
-            key = "'member:' + #memberId + ':page:0:size:3'",
-            cacheManager = "myCacheManager")
     public RequestCreateResponse createReRequest(Long memberId, Long requestId, ReRequestCreateRequest reRequestCreateRequest) {
         Member member = memberService.getMemberWithProjectOrThrow(memberId);
         Request parentRequest = requestService.getRequestOrThrow(requestId);
         Stage stage = stageService.getStageOrThrow(parentRequest.getStage().getId());
         projectValidator.validateProjectDevAuthority(member, stage.getProject().getId());
         requestValidator.validateRequestStatus(parentRequest);
+        requestCacheEvictForCreate(memberId, reRequestCreateRequest.getMembers());
 
         return requestService.createReRequest(requestId, member, stage, reRequestCreateRequest);
     }
 
+    private void requestCacheEvictForCreate(Long memberId, List<MemberAssignDTO> members) {
+        cacheEvictionHelper.evictMyRequestPage0Size3(memberId);
+
+        for (MemberAssignDTO memberAssign : members) {
+            Long approverId = memberAssign.getId();
+            if (approverId != null) {
+                cacheEvictionHelper.evictMyRequestPage0Size3(approverId);
+            }
+        }
+    }
+
     @LoggableEntityAction(action = "UPDATE", entityClass = Request.class)
     @Transactional
-    @CacheEvict(value = "myRequests",
-            key = "'member:' + #memberId + ':page:0:size:3'",
-            cacheManager = "myCacheManager")
     public RequestUpdateResponse updateRequest(Long memberId, Long requestId, RequestUpdateRequest requestUpdateRequest) {
         Request request = requestService.getRequestOrThrow(requestId);
         requestValidator.validaRequestWriter(memberId, request);
+        requestCacheEvict(memberId, request);
 
         return requestService.updateRequest(request, requestUpdateRequest);
     }
 
     @LoggableEntityAction(action = "DELETE", entityClass = Request.class)
     @Transactional
-    @CacheEvict(value = "myRequests",
-            key = "'member:' + #memberId + ':page:0:size:3'",
-            cacheManager = "myCacheManager")
     public RequestDeleteResponse deleteRequest(Long memberId, Long requestId) {
         Request request = requestService.getRequestOrThrow(requestId);
         requestValidator.validaRequestWriter(memberId, request);
+        requestCacheEvict(memberId, request);
 
         return requestService.deleteRequest(request);
+    }
+
+    private void requestCacheEvict(Long memberId, Request request) {
+        cacheEvictionHelper.evictMyRequestPage0Size3(memberId);
+
+        for (ApproverDesignation approver : request.getApprovers()) {
+            cacheEvictionHelper.evictMyRequestPage0Size3(approver.getMember().getId());
+        }
     }
 
     public Page<RequestDTO> findRequests(Long projectId, GetRequestCondition condition, Pageable pageable) {

--- a/src/main/java/com/soda/project/interfaces/stage/request/dto/RequestDTO.java
+++ b/src/main/java/com/soda/project/interfaces/stage/request/dto/RequestDTO.java
@@ -7,12 +7,14 @@ import com.soda.project.interfaces.stage.common.file.dto.FileDTO;
 import com.soda.project.interfaces.stage.common.link.dto.LinkDTO;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@NoArgsConstructor
 public class RequestDTO {
     private Long requestId;
     private Long projectId;


### PR DESCRIPTION

# 요약
- 일반 대시보드에 있어 조회가 가장 잦은 API 중 하나인 "특정 유저의 최근 승인요청" 조회 시 레디스에서 Look Aside하게 조회하도록 수정.
- 승인요청이 생성/수정/삭제 되었을 때 memberId바탕으로 구성한 캐시 key를 무효화하도록 하여 데이터 정합성을 지킴
- 데이터 정합성이 항상 잘 지켜지는 무효화 전략이여서 TTL은 비교적 길게 24시간으로 설정하였음.


# 연관 이슈
#357 


# 개선 결과
![image](https://github.com/user-attachments/assets/1d21c2c5-78ed-4bd0-a66a-c72038569e88)
평균 30~40ms의 응답속도를 보임
응답 속도 50% 이상 개선